### PR TITLE
Align Vim syntax and detection with BIRD 2.19 / 3.3

### DIFF
--- a/.github/workflows/vim.yml
+++ b/.github/workflows/vim.yml
@@ -1,0 +1,30 @@
+name: Vim compatibility
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Vim ${{ matrix.vim }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        vim: ["v8.2.0000", "stable"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/action-setup-vim@v1
+        with:
+          version: ${{ matrix.vim }}
+      - name: Source syntax
+        run: vim -Nu NONE -n -es -c 'set nomore' -c 'source syntax/bird2.vim' -c 'qa!'
+      - name: Test syntax groups
+        run: vim -Nu NONE -n -es -V1 -S tests/syntax.vim
+      - name: Test filetype detection
+        run: vim -Nu NONE -n -es -V1 -S tests/ftdetect.vim
+      - name: Test filetype plugin
+        run: vim -Nu NONE -n -es -V1 -S tests/ftplugin.vim

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Vim swap files
+.worktrees/
 *.swp
 *.swo
 *.swn

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**Vim syntax highlighting for BIRD2 configuration files**
+**Vim syntax highlighting for BIRD 2 and BIRD 3 configuration files**
 
 English | [简体中文](README.zh-CN.md)
 
@@ -13,13 +13,13 @@ English | [简体中文](README.zh-CN.md)
 
 ## Overview
 
-`bird2.vim` provides Vim syntax highlighting, filetype detection, and filetype plugin support for [BIRD2](https://bird.network.cz/) configuration files.
+`bird2.vim` provides Vim syntax highlighting, filetype detection, and filetype plugin support for BIRD 2 and BIRD 3 configuration files.
 
 This is the Vim plugin component of the [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) project by the BIRD Chinese Community.
 
 ## Features
 
-- Syntax highlighting for all BIRD2 configuration elements
+- Syntax highlighting aligned with current BIRD 2.19 and BIRD 3.3 syntax
 - Automatic filetype detection for `.bird`, `.bird2`, `.bird3`, and `.conf` files
 - Smart heuristic detection for generic `.conf` files
 - Filetype-specific settings (comments, format options, etc.)
@@ -61,14 +61,12 @@ bash scripts/install.sh
 
 ## Filetype Detection
 
-The plugin automatically detects BIRD2 configuration files by:
+The plugin automatically detects BIRD 2 and BIRD 3 configuration files by:
 
-- **Extension**: `.bird`, `.bird2`, `.bird3`, `.bird*.conf`
-- **Filename**: `bird.conf`, `bird6.conf`
-- **Content**: Scans first 200 lines of `.conf` files for BIRD2-specific patterns:
-  - Protocol definitions (`protocol bgp`, `protocol ospf`, etc.)
-  - Keywords like `router id`, `template`, `filter`, `function`
-  - Flow/ROA table definitions
+- **Extension**: `.bird`, `.bird2`, `.bird3`
+- **Filename**: `bird.conf`, `bird2.conf`, `bird3.conf`, `bird6.conf`, and explicit `bird-*`/`*.bird*.conf` variants
+- **Known paths**: configuration files below `bird`, `bird2`, or `bird3` directories
+- **Content**: scans the first 200 lines of generic `.conf` files. Strong BIRD-only constructs are accepted immediately; generic constructs require two independent signals to reduce false positives.
 
 ## Documentation
 
@@ -115,7 +113,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## Related Projects
 
-- [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) - TextMate grammar for BIRD2
+- [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) - TextMate grammar for BIRD 2 and BIRD 3
 - [bird2.nvim](https://github.com/bird-chinese-community/bird2.nvim) - Neovim plugin
 - [vscode-bird2](https://github.com/bird-chinese-community/vscode-bird2-conf) - VS Code extension
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**BIRD2 配置文件的 Vim 语法高亮插件**
+**BIRD 2 与 BIRD 3 配置文件的 Vim 语法高亮插件**
 
 [English](README.md) | 简体中文
 
@@ -13,13 +13,13 @@
 
 ## 概述
 
-`bird2.vim` 为 [BIRD2](https://bird.network.cz/) 配置文件提供 Vim 语法高亮、文件类型检测和文件类型插件支持。
+`bird2.vim` 为 BIRD 2 与 BIRD 3 配置文件提供 Vim 语法高亮、文件类型检测和文件类型插件支持。
 
 这是 [BIRD 中文社区](https://github.com/bird-chinese-community) 的 [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) 项目的 Vim 插件组件。
 
 ## 功能特性
 
-- 完整的 BIRD2 配置语法高亮
+- 与当前 BIRD 2.19 和 BIRD 3.3 对齐的配置语法高亮
 - 自动文件类型检测（`.bird`, `.bird2`, `.bird3`, `.conf` 等扩展名）
 - 对通用 `.conf` 文件的智能启发式检测
 - 文件类型特定设置（注释、格式选项等）
@@ -61,14 +61,12 @@ bash scripts/install.sh
 
 ## 文件类型检测
 
-插件通过以下方式自动检测 BIRD2 配置文件：
+插件通过以下方式自动检测 BIRD 2 与 BIRD 3 配置文件：
 
-- **扩展名**：`.bird`, `.bird2`, `.bird3`, `.bird*.conf`
-- **文件名**：`bird.conf`, `bird6.conf`
-- **内容检测**：扫描 `.conf` 文件的前 200 行，查找 BIRD2 特定模式：
-  - 协议定义（`protocol bgp`, `protocol ospf` 等）
-  - 关键字如 `router id`, `template`, `filter`, `function`
-  - Flow/ROA 表定义
+- **扩展名**：`.bird`、`.bird2`、`.bird3`
+- **文件名**：`bird.conf`、`bird2.conf`、`bird3.conf`、`bird6.conf`，以及明确的 `bird-*`/`*.bird*.conf` 变体
+- **已知路径**：位于 `bird`、`bird2` 或 `bird3` 目录下的配置文件
+- **内容检测**：扫描通用 `.conf` 文件的前 200 行；BIRD 独有结构会直接命中，通用结构需要两个独立信号，从而减少误判。
 
 ## 文档
 
@@ -115,7 +113,7 @@ autocmd BufRead,BufNewFile *.myext setfiletype bird2
 
 ## 相关项目
 
-- [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) - BIRD2 的 TextMate 语法
+- [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) - BIRD 2 与 BIRD 3 的 TextMate 语法
 - [bird2.nvim](https://github.com/bird-chinese-community/bird2.nvim) - Neovim 插件
 - [vscode-bird2](https://github.com/bird-chinese-community/vscode-bird2-conf) - VS Code 扩展
 

--- a/doc/bird2.txt
+++ b/doc/bird2.txt
@@ -2,7 +2,7 @@
 
 Author:  BIRD Chinese Community <dev-bird@xmsl.dev>
 License: MPL-2.0
-Version: 1.0.12
+Version: 1.0.13
 
 ==============================================================================
 CONTENTS					*bird2-contents*
@@ -160,7 +160,7 @@ vscode-bird2 ~
 ==============================================================================
 CHANGELOG					*bird2-changelog*
 
-1.0.12 (2026-07-16)~
+1.0.13 (2026-07-17)~
 	- Align keywords, enums, CLI phrases, attributes, and operators with current
 	  BIRD 2.19 and BIRD 3.3 source trees
 	- Add scored content detection with bounded comment-aware scanning

--- a/doc/bird2.txt
+++ b/doc/bird2.txt
@@ -2,7 +2,7 @@
 
 Author:  BIRD Chinese Community <dev-bird@xmsl.dev>
 License: MPL-2.0
-Version: 1.0.9
+Version: 1.0.12
 
 ==============================================================================
 CONTENTS					*bird2-contents*
@@ -21,13 +21,13 @@ CONTENTS					*bird2-contents*
 INTRODUCTION					*bird2-introduction*
 
 The bird2.vim plugin provides syntax highlighting and filetype detection for
-BIRD2 (BIRD Internet Routing Daemon) configuration files.
+BIRD 2 and BIRD 3 (BIRD Internet Routing Daemon) configuration files.
 
 BIRD is a dynamic IP routing daemon supporting IPv4 and IPv6 protocols,
 including BGP, OSPF, RIP, and static routing.
 
 Features:
-	- Full syntax highlighting for BIRD2 configuration
+	- Syntax highlighting aligned with BIRD 2.19 and BIRD 3.3
 	- Automatic filetype detection
 	- Heuristic detection for generic .conf files
 	- Filetype plugin with sensible defaults
@@ -72,16 +72,16 @@ FILETYPE DETECTION				*bird2-filetype-detection*
 The plugin automatically detects BIRD2 configuration files by:
 
 EXTENSIONS ~
-	*.bird, *.bird2, *.bird3, *.bird*.conf
+	*.bird, *.bird2, *.bird3, *.bird.conf, *.bird2.conf, *.bird3.conf
 
 FILENAMES ~
-	bird.conf, bird6.conf
+	bird.conf, bird2.conf, bird3.conf, bird6.conf, bird-*.conf
 
 CONTENT HEURISTICS ~
-	For generic .conf files, the plugin scans the first 200 lines for:
-	- Protocol definitions (protocol bgp, ospf, rip, etc.)
-	- Keywords: router id, template, filter, function, table
-	- Flow/ROA table definitions
+	For generic .conf files, the plugin scans the first 200 lines. BIRD-only
+	protocols, typed tables, and router id are strong signals. Otherwise two
+	independent policy/declaration signals are required to avoid false positives.
+	Comments are ignored, and an existing non-conf filetype is preserved.
 
 To verify filetype detection: >
 	:verbose set ft?
@@ -112,8 +112,7 @@ KEYWORDS ~
 
 PROTOCOLS ~
 	bgp, ospf, rip, device, direct, kernel, pipe, babel, radv, rpki, bfd,
-	bmp,
-	static, l3vpn, mrt, perf
+	bmp, static, l3vpn, mrt, perf, aggregator, bridge, evpn
 
 DATA TYPES ~
 	- Integers: 42, 0x1a
@@ -160,6 +159,12 @@ vscode-bird2 ~
 
 ==============================================================================
 CHANGELOG					*bird2-changelog*
+
+1.0.12 (2026-07-16)~
+	- Align keywords, enums, CLI phrases, attributes, and operators with current
+	  BIRD 2.19 and BIRD 3.3 source trees
+	- Add scored content detection with bounded comment-aware scanning
+	- Implement working buffer-local comment mappings without changing cwd
 
 1.0.9 (2026-03-06)~
 	- Add local/neighbor statement highlighting for symbolic ASNs

--- a/ftdetect/bird2.vim
+++ b/ftdetect/bird2.vim
@@ -1,54 +1,97 @@
 augroup bird2_ftdetect
   autocmd!
-  
-  " Filename-based detection
-  autocmd BufRead,BufNewFile *.bird,*.bird2,*.bird3,*.bird*.conf setfiletype bird2
-  autocmd BufRead,BufNewFile bird.conf,bird6.conf setfiletype bird2
-  
-  " Heuristic detection for generic *.conf (scan first 200 lines)
+
+  " Filename-based detection. Keep patterns specific enough to avoid files
+  " such as bluebird.conf or hummingbird.conf.
+  autocmd BufRead,BufNewFile *.bird,*.bird2,*.bird3 setfiletype bird2
+  autocmd BufRead,BufNewFile bird.conf,bird2.conf,bird3.conf,bird6.conf setfiletype bird2
+  autocmd BufRead,BufNewFile bird-*.conf,bird_*.conf,bird.*.conf setfiletype bird2
+  autocmd BufRead,BufNewFile *.bird.conf,*.bird2.conf,*.bird3.conf setfiletype bird2
+  autocmd BufRead,BufNewFile */bird/*.conf,*/bird2/*.conf,*/bird3/*.conf setfiletype bird2
+
+  function! s:SetBird2Filetype() abort
+    if &l:filetype ==# 'conf'
+      setlocal filetype=bird2
+    else
+      setfiletype bird2
+    endif
+  endfunction
+
   function! s:Bird2MaybeSetFiletype() abort
-    " Skip if filetype already set (except for generic 'conf')
-    if &filetype !=# '' && &filetype !=# 'conf'
+    if !get(g:, 'bird2_heuristic_detect', 1)
       return
     endif
-    
+
+    if &l:filetype !=# '' && &l:filetype !=# 'conf'
+      return
+    endif
+
     let l:max_lines = min([200, line('$')])
     if l:max_lines <= 0
       return
     endif
-    
-    " Enhanced pattern matching for BIRD-specific keywords
-    " Includes: protocols, router id, templates, filters, flow/roa tables, static routes
-    " Split into simpler patterns to avoid NFA regexp complexity errors
-    let l:patterns = [
-      \ '\<protocol\s\+\(bgp\|ospf\|rip\|device\|direct\|kernel\|pipe\|babel\|radv\|rpki\|bfd\|static\)\>',
+
+    let l:protocols = '\%(aggregator\|babel\|bfd\|bgp\|bmp\|bridge\|device\|direct\|evpn\|kernel\|l3vpn\|mrt\|ospf\|perf\|pipe\|radv\|rip\|rpki\|static\)'
+    let l:strong_patterns = [
       \ '^\s*router\s\+id\>',
-      \ '^\s*template\>',
-      \ '^\s*filter\>',
-      \ '\<flow[46]\>',
-      \ '\<roa[46]\>',
-      \ '^\s*table\>',
-      \ '^\s*define\>',
-      \ '^\s*function\>',
-      \ '\<ipv[46]\s\+table\>'
+      \ '^\s*\%(protocol\|template\)\s\+' . l:protocols . '\>',
+      \ '^\s*\%(ipv4\|ipv6\|vpn4\|vpn6\|flow4\|flow6\|roa4\|roa6\|aspa\|mpls\|evpn\)\%(-\%(mc\|mpls\|sadr\)\)\?\s\+table\>',
       \ ]
-    
-    for lnum in range(1, l:max_lines)
-      let l:line = getline(lnum)
-      " Skip empty lines and comments for efficiency
-      if l:line =~# '^\s*$' || l:line =~# '^\s*#'
+    let l:signal_patterns = {
+      \ 'filter': '^\s*filter\s\+\S\+',
+      \ 'function': '^\s*function\s\+\S\+',
+      \ 'define': '^\s*define\s\+\S\+\s*=',
+      \ 'table': '^\s*table\s\+\S\+\s*{',
+      \ 'policy': '^\s*\%(import\|export\)\s\+\%(all\|none\|filter\|where\)\>',
+      \ 'decision': '^\s*\%(accept\|reject\)\s*;',
+      \ 'include': '^\s*include\s\+["'']',
+      \ }
+    let l:seen = {}
+    let l:score = 0
+    let l:in_block_comment = 0
+
+    for l:lnum in range(1, l:max_lines)
+      let l:line = getline(l:lnum)
+
+      if l:in_block_comment
+        if l:line !~# '\*/'
+          continue
+        endif
+        let l:line = substitute(l:line, '^.*\*/', '', '')
+        let l:in_block_comment = 0
+      endif
+
+      if l:line =~# '/\*'
+        if l:line !~# '\*/'
+          let l:in_block_comment = 1
+        endif
+        let l:line = substitute(l:line, '/\*.*\%\(\*/\|$\)', '', 'g')
+      endif
+
+      let l:line = substitute(l:line, '#.*$', '', '')
+      if l:line =~# '^\s*$'
         continue
       endif
-      
-      " Check each pattern separately
-      for l:pat in l:patterns
-        if l:line =~? l:pat
-          setfiletype bird2
+
+      for l:pattern in l:strong_patterns
+        if l:line =~? l:pattern
+          call s:SetBird2Filetype()
           return
+        endif
+      endfor
+
+      for [l:name, l:pattern] in items(l:signal_patterns)
+        if !has_key(l:seen, l:name) && l:line =~? l:pattern
+          let l:seen[l:name] = 1
+          let l:score += 1
+          if l:score >= 2
+            call s:SetBird2Filetype()
+            return
+          endif
         endif
       endfor
     endfor
   endfunction
-  
+
   autocmd BufRead,BufNewFile *.conf call s:Bird2MaybeSetFiletype()
 augroup END

--- a/ftdetect/bird2.vim
+++ b/ftdetect/bird2.vim
@@ -35,7 +35,8 @@ augroup bird2_ftdetect
     let l:strong_patterns = [
       \ '^\s*router\s\+id\>',
       \ '^\s*\%(protocol\|template\)\s\+' . l:protocols . '\>',
-      \ '^\s*\%(ipv4\|ipv6\|vpn4\|vpn6\|flow4\|flow6\|roa4\|roa6\|aspa\|mpls\|evpn\)\%(-\%(mc\|mpls\|sadr\)\)\?\s\+table\>',
+      \ '^\s*\%(ipv4\|ipv6\|vpn4\|vpn6\|flow4\|flow6\|roa4\|roa6\|eth\|aspa\|evpn\|mpls\|neighbor\)\s\+table\>',
+      \ '^\s*ipv6\s\+sadr\s\+table\>',
       \ ]
     let l:signal_patterns = {
       \ 'filter': '^\s*filter\s\+\S\+',
@@ -93,5 +94,6 @@ augroup bird2_ftdetect
     endfor
   endfunction
 
-  autocmd BufRead,BufNewFile *.conf call s:Bird2MaybeSetFiletype()
+  autocmd BufRead,BufNewFile,BufWritePost *.conf call s:Bird2MaybeSetFiletype()
+  autocmd FileType conf call s:Bird2MaybeSetFiletype()
 augroup END

--- a/ftplugin/bird2.vim
+++ b/ftplugin/bird2.vim
@@ -1,5 +1,5 @@
-" BIRD2 filetype plugin
-" Language: BIRD2 Configuration
+" BIRD 2/3 filetype plugin
+" Language: BIRD 2/3 Configuration
 " License:  MPL-2.0
 " Author:   BIRD Chinese Community
 
@@ -21,10 +21,40 @@ if exists("g:syntax_on")
   syntax sync fromstart
 endif
 
-" Define buffer-local mappings for comment/uncomment
-if !hasmapto('<Plug>Bird2Comment', 'n')
-  nmap <buffer> <Plug>Bird2Comment <Leader>c
-  vmap <buffer> <Plug>Bird2Comment <Leader>c
+function! s:ToggleCommentLine(lnum) abort
+  let l:line = getline(a:lnum)
+
+  if l:line =~# '^\s*#'
+    call setline(a:lnum, substitute(l:line, '^\(\s*\)#\s\?', '\1', ''))
+    return
+  endif
+
+  let l:indent = matchstr(l:line, '^\s*')
+  call setline(a:lnum, l:indent . '# ' . strpart(l:line, strlen(l:indent)))
+endfunction
+
+function! s:ToggleCommentRange(first, last) abort
+  for l:lnum in range(a:first, a:last)
+    call s:ToggleCommentLine(l:lnum)
+  endfor
+endfunction
+
+" Provide stable <Plug> mappings and only claim <Leader>c when it is unused.
+nnoremap <silent> <buffer> <Plug>Bird2Comment :<C-U>call <SID>ToggleCommentLine(line('.'))<CR>
+xnoremap <silent> <buffer> <Plug>Bird2Comment :<C-U>call <SID>ToggleCommentRange(line("'<"), line("'>"))<CR>
+
+let b:undo_ftplugin = 'setlocal comments< commentstring< formatoptions< matchpairs< omnifunc<'
+      \ . ' | silent! nunmap <buffer> <Plug>Bird2Comment'
+      \ . ' | silent! xunmap <buffer> <Plug>Bird2Comment'
+
+if empty(maparg('<Leader>c', 'n'))
+  nmap <silent> <buffer> <Leader>c <Plug>Bird2Comment
+  let b:undo_ftplugin .= ' | silent! nunmap <buffer> <Leader>c'
+endif
+
+if empty(maparg('<Leader>c', 'x'))
+  xmap <silent> <buffer> <Leader>c <Plug>Bird2Comment
+  let b:undo_ftplugin .= ' | silent! xunmap <buffer> <Leader>c'
 endif
 
 " Set 'matchpairs' for BIRD2 config braces
@@ -32,11 +62,3 @@ setlocal matchpairs+=(:),{:},[:]
 
 " Omni completion function (can be extended)
 setlocal omnifunc=syntaxcomplete#Complete
-
-" Change to the BIRD2 config directory automatically
-if has("finddir")
-  let s:bird_config = findfile("bird.conf", ".;")
-  if s:bird_config != "" && getftime(s:bird_config) > 0
-    lcd %:p:h
-  endif
-endif

--- a/syntax/bird2.vim
+++ b/syntax/bird2.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language: BIRD2 Configuration
 " Scope:    BIRD2 config files (bird2, .conf)
-" Version:  1.0.12-20260716
+" Version:  1.0.13-20260717
 " License:  MPL-2.0
 " Author:   BIRD Chinese Community (Alice39s) <dev-bird@xmsl.dev>
-" Based on: grammars/bird2.tmLanguage.json (1.0.12-20260716)
+" Based on: grammars/bird2.tmLanguage.json (1.0.13-20260717)
 
 " ------------------------
 " Initialization

--- a/syntax/bird2.vim
+++ b/syntax/bird2.vim
@@ -77,8 +77,8 @@ syn match  bird2ASN        "\<[0-9]\+\>" contained
 " Prefixes (repository.prefixes)
 " ------------------------
 syn match  bird2Prefix     "\<[0-9]\{1,3}\.[0-9]\{1,3}\.[0-9]\{1,3}\.[0-9]\{1,3}\/[0-9]\{1,2}\>\%([\+\-]\)\?"
-syn match  bird2Prefix     "\<[0-9a-fA-F:]\+\/[0-9]\{1,3}\>\%([\+\-]\)\?"
-syn match  bird2Prefix     "\<[0-9]\{1,3}\.[0-9]\{1,3}\.[0-9]\{1,3}\.[0-9]\{1,3}\/[0-9]\{1,2}{[0-9]\+,[0-9]\+}\>"
+syn match  bird2Prefix     "\%([0-9A-Za-z_:]\)\@<!\%([0-9a-fA-F]\{0,4}:\)\{1,7}[0-9a-fA-F]\{0,4}\/[0-9]\{1,3}\>\%([\+\-]\)\?"
+syn match  bird2Prefix     "\<[0-9]\{1,3}\.[0-9]\{1,3}\.[0-9]\{1,3}\.[0-9]\{1,3}\/[0-9]\{1,2}\>{[0-9]\+,[0-9]\+}"
 
 " ------------------------
 " Filter Definitions (repository.filter-definitions)
@@ -232,7 +232,7 @@ syn keyword bird2SemanticModifier self on off remote extended native ipv6 intern
 " ------------------------
 " Built-in Functions (repository.builtin-functions)
 " ------------------------
-syn keyword bird2BuiltinFunc defined unset roa_check aspa_check aspa_check_downstream aspa_check_upstream from_hex format append prepend add delete empty reset bt_assert bt_test_suite bt_test_same
+syn keyword bird2BuiltinFunc defined unset roa_check aspa_check aspa_check_downstream aspa_check_upstream from_hex format append prepend add delete empty reset bt_assert bt_check_assign bt_test_suite bt_test_same
 
 " ------------------------
 " Method Properties (repository.method-properties)

--- a/syntax/bird2.vim
+++ b/syntax/bird2.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language: BIRD2 Configuration
 " Scope:    BIRD2 config files (bird2, .conf)
-" Version:  1.0.11-20260611
+" Version:  1.0.12-20260716
 " License:  MPL-2.0
 " Author:   BIRD Chinese Community (Alice39s) <dev-bird@xmsl.dev>
-" Based on: grammars/bird2.tmLanguage.json (1.0.11-20260611)
+" Based on: grammars/bird2.tmLanguage.json (1.0.12-20260716)
 
 " ------------------------
 " Initialization
@@ -17,6 +17,10 @@ endif
 " Syntax case
 " ------------------------
 syntax case match
+
+" Generic identifiers are defined before specialized matches so protocol
+" phrases, attributes, constants, and operators retain priority.
+syn match  bird2Variable    "[a-zA-Z_][a-zA-Z0-9_]*\>"
 
 " ------------------------
 " Comments (repository.comments)
@@ -119,10 +123,10 @@ syn match  bird2NextHopIPv4 "\<next hop\>\s\+ipv4\s\+[0-9\.]\+" contains=bird2Ro
 syn match  bird2NextHopIPv6 "\<next hop\>\s\+ipv6\s\+[0-9a-fA-F:]\+" contains=bird2RoutingKw,bird2IPv6
 syn match  bird2NextHopSelf "\<next hop\>\s\+self\>" contains=bird2RoutingKw,bird2SemanticModifier
 syn match  bird2ExtendedNextHop "\<extended next hop\>\s\+\%(on\|off\)\>" contains=bird2RoutingKw,bird2SemanticModifier
-syn match  bird2NextHopPrefer "\<next hop\>\s\+prefer\s\+\%(native\|ipv6\)\>" contains=bird2RoutingKw,bird2SemanticModifier
-syn match  bird2NextHopKeep   "\<next hop\>\s\+keep\>" contains=bird2RoutingKw,bird2SemanticModifier
+syn match  bird2NextHopPrefer "\<next hop\>\s\+prefer\s\+\%(global\|local\|native\|ipv6\)\>" contains=bird2RoutingKw,bird2SemanticModifier
+syn match  bird2NextHopKeep   "\<next hop\>\s\+keep\%(\s\+\%(ibgp\|ebgp\)\)\?\>" contains=bird2RoutingKw,bird2SemanticModifier
 syn match  bird2NextHopAddr   "\<next hop\>\s\+address\s\+[0-9a-fA-F:.]\+" contains=bird2RoutingKw,bird2IPv4,bird2IPv6
-syn match  bird2RequireExtNexthop "\<require extended next hop\>\s\+\%(on\|off\)\>" contains=bird2RoutingKw,bird2SemanticModifier
+syn match  bird2RequireExtNexthop "\<require extended next hop\>\s\+\%(yes\|no\|on\|off\|true\|false\)\>" contains=bird2RoutingKw,bird2SemanticModifier
 
 " ------------------------
 " Neighbor Statements (repository.neighbor-statements)
@@ -143,6 +147,7 @@ syn match  bird2SourceAddress "\<source address\>\s\+[0-9a-fA-F:.]\+" contains=b
 syn match  bird2ImportFilter "\<import\>\s\+filter\s\+\%([a-zA-Z_][a-zA-Z0-9_]*\|'[0-9A-Za-z_.:-]\+'\)" contains=bird2Keyword,bird2FilterReference
 syn region bird2ImportFilterInline matchgroup=bird2Keyword start="\<import\>\s\+filter\s*{" matchgroup=bird2Delimiter end="}" contains=@bird2All fold keepend
 syn region bird2ExportWhere matchgroup=bird2Keyword start="\<export\>\s\+where\>" end=";" contains=@bird2All
+syn region bird2ExportPrefilter matchgroup=bird2Keyword start="\<export\>\s\+in\>" end=";" contains=@bird2All
 syn match  bird2ExportFilter "\<export\>\s\+filter\s\+\%([a-zA-Z_][a-zA-Z0-9_]*\|'[0-9A-Za-z_.:-]\+'\)" contains=bird2Keyword,bird2FilterReference
 
 " ------------------------
@@ -167,31 +172,57 @@ syn keyword bird2Structure  table define include attribute eval ipv4 ipv6 local 
 " Functional Keywords (repository.functional-keywords)
 " ------------------------
 " Protocol types
-syn keyword bird2ProtocolTypeKw static rip ospf bgp babel rpki bfd bmp device direct kernel pipe perf mrt aggregator l3vpn radv
+syn keyword bird2ProtocolTypeKw static rip ospf bgp babel rpki bfd bmp device direct kernel pipe perf mrt aggregator l3vpn radv bridge evpn
 " Routing keywords
-syn keyword bird2RoutingKw  graceful restart preference disabled hold keepalive connect start delay error wait forget scan randomize router id route neighbor
+syn keyword bird2RoutingKw  graceful restart preference disabled hold keepalive connect retry start delay error wait forget scan randomize router id route neighbor provider customer rs_server rs_client
+" Device keywords
+syn keyword bird2DeviceKw   preferred
 " Interface keywords
 syn keyword bird2InterfaceKw interface type wired wireless tunnel rxcost limit hello update interval port tx class dscp priority rx buffer length check link rtt cost min max decay send timestamps
 " RPKI keywords
 syn keyword bird2RpkiKw      refresh retry expire transport ssh tcp user address version ignore private public key
 syn match   bird2RpkiPhraseKw "\<\%(local\s\+address\|ignore\s\+max\s\+length\|min\s\+version\|max\s\+version\|bird\s\+private\s\+key\|remote\s\+public\s\+key\)\>"
 " Authentication keywords
-syn keyword bird2AuthKw     authentication none mac permissive password generate accept from to algorithm hmac sha1 sha256 sha384 sha512 blake2s128 blake2s256 blake2b256 blake2b512
+syn keyword bird2AuthKw     authentication none permissive password generate accept from to algorithm hmac cmac aes128 sha1 sha224 sha256 sha384 sha512 blake2s128 blake2s256 blake2b256 blake2b512 ao key keys secret deprecated preferred
 " Time keyword
 syn keyword bird2TimeKw     time
 " Config keywords
-syn keyword bird2ConfigKw   hostname description debug log syslog stderr bird protocols tables channels timeouts passwords bfd confederation cluster stub dead neighbors area md5 multihop passive rfc1583compat tick ls retransmit transmit ack state database summary external nssa translator always candidate never role stability election action warn block disable keep filtered receive modify add delete withdraw unreachable blackhole prohibit unreach igp_metric localpref med origin community large_community ext_community as_path prepend weight gateway scope onlink recursive multipath igp channel sadr src learn persist via ng all none master4
+syn keyword bird2ConfigKw   hostname description log syslog stderr udp cli bird protocols tables channels timeouts passwords bfd confederation cluster stub dead neighbors area md5 multihop passive rfc1583compat tick ls retransmit transmit ack state database summary external nssa translator always candidate never role stability election action warn warning auth bug fatal info trace block disable keep filtered receive modify add delete withdraw unreachable blackhole prohibit unreach igp_metric localpref med origin community large_community ext_community as_path prepend weight gateway scope onlink recursive multipath igp channel sadr src learn persist via ng threads thread group cork threshold settle digest fixed ping wakeup scheduling sockets allocator timers mrtdump timeformat preexport noexport exported stats count rpki reload all none master4
 " Flowspec keywords
 syn keyword bird2FlowspecKw flow4 flow6 dst src proto header dport sport icmp code tcp flags dscp dont_fragment is_fragment first_fragment last_fragment fragment label offset
 " Address keywords
-syn keyword bird2AddressKw  vpn4 vpn6 mpls aspa roa4 roa6
-syn match   bird2BfdPhraseKw "\<\%(strict\s\+bind\|zero\s\+udp6\s\+checksum\s\+rx\|idle\s\+tx\s\+interval\|multiplier\|keyed\|meticulous\)\>"
-syn match   bird2BabelPhraseKw "\<\%(send\s\+timestamps\|rtt\s\+\%(cost\|min\|max\|decay\)\|next\s\+hop\s\+prefer\|prefer\|native\)\>"
-syn match   bird2BgpPhraseKw "\<\%(next\s\+hop\s\+\%(self\|address\|ibgp\|ebgp\)\|link\s\+local\s\+next\s\+hop\s\+format\|import\s\+table\|export\s\+table\|base\s\+table\|add\s\+paths\|aigp\s\+originate\|long\s\+lived\s\+graceful\s\+restart\|long\s\+lived\s\+stale\s\+time\|dynamic\s\+name\%(\s\+digits\)\?\|free\s\+bind\|ttl\s\+security\|multihop\s\+password\|rr\s\+client\|rs\s\+client\|advertise\s\+hostname\|interpret\s\+communities\|deterministic\s\+med\|default\s\+bgp_local_pref\|default\s\+bgp_med\|med\s\+metric\|igp\s\+metric\|missing\s\+lladdr\|gateway\s\+address\|forwarding\s\+addressed\|gateway\s\+recursive\|allow\s\+local\s\+as\|allow\s\+bogus\s\+as\|originate\s\+community\|full\s\+route\s\+table\|capabilities\|primary\)\>"
-syn match   bird2OspfPhraseKw "\<\%(no\s\+summary\|transmit\s\+delay\|strict\s\+nonbroadcast\|stub\s\+router\|real\s\+bdr\|instance\s\+id\)\>"
-syn match   bird2RipPhraseKw "\<\%(split\s\+horizon\|honor\s\+neighbor\|honor\s\+always\|garbage\s\+time\|timeout\s\+time\)\>"
-syn match   bird2KernelPhraseKw "\<\%(merge\s\+paths\|kernel\s\+table\)\>"
+syn keyword bird2AddressKw  ipv4_mc ipv6_mc vpn4 vpn6 mpls aspa roa4 roa6 eth evpn neighbor pri sec
+syn match   bird2AddressKw  "\<\%(ipv4-mpls\|ipv6-mpls\|ipv6-sadr\|vpn4-mc\|vpn4-mpls\|vpn6-mc\|vpn6-mpls\)\>"
+syn match   bird2BfdPhraseKw "\<\%(strict\s\+bind\|zero\s\+udp6\s\+checksum\s\+rx\|idle\s\+tx\s\+interval\|express\s\+thread\s\+group\|multiplier\|keyed\|meticulous\)\>"
+syn match   bird2BabelPhraseKw "\<\%(randomize\s\+router\s\+id\|show\s\+babel\s\+\%(interfaces\|neighbors\|entries\|routes\)\|send\s\+timestamps\|rtt\s\+\%(cost\|min\|max\|decay\)\|next\s\+hop\s\+\%(ipv4\|ipv6\|prefer\)\|extended\s\+next\s\+hop\|prefer\|native\)\>"
+syn match   bird2BgpPhraseKw "\<\%(next\s\+hop\s\+\%(self\|address\|ibgp\|ebgp\)\|link\s\+local\s\+next\s\+hop\s\+format\%(\s\+\%(native\|single\|double\)\)\?\|import\s\+table\|export\s\+table\|base\s\+table\|add\s\+paths\|enable\s\+route\s\+refresh\|enable\s\+enhanced\s\+route\s\+refresh\|require\s\+route\s\+refresh\|require\s\+enhanced\s\+route\s\+refresh\|enable\s\+as4\|require\s\+as4\|enable\s\+extended\s\+messages\|require\s\+extended\s\+messages\|require\s\+hostname\|disable\s\+after\s\+error\|disable\s\+after\s\+cease\|enforce\s\+first\s\+as\|neighbor\s\+range\|interface\s\+range\|aigp\s\+originate\|min\s\+graceful\s\+restart\s\+time\|max\s\+graceful\s\+restart\s\+time\|graceful\s\+restart\s\+time\|require\s\+graceful\s\+restart\|require\s\+long\s\+lived\s\+graceful\s\+restart\|long\s\+lived\s\+graceful\s\+restart\|long\s\+lived\s\+stale\s\+time\|dynamic\s\+name\%(\s\+digits\)\?\|free\s\+bind\|ttl\s\+security\|multihop\s\+password\|local\s\+role\|require\s\+roles\|rr\s\+client\|rs\s\+client\|advertise\s\+hostname\|interpret\s\+communities\|deterministic\s\+med\|default\s\+bgp_local_pref\|default\s\+bgp_med\|med\s\+metric\|igp\s\+metric\|tx\s\+size\s\+warning\|missing\s\+lladdr\|gateway\s\+address\|forwarding\s\+addressed\|gateway\s\+recursive\|allow\s\+local\s\+as\|allow\s\+bogus\s\+as\|originate\s\+community\|full\s\+route\s\+table\|mandatory\|secondary\|validate\|capabilities\|primary\|aigp\|authentication\s\+ao\|send\s\+id\|recv\s\+id\|cmac\s\+aes128\|prefix\s\+limit\s\+hit\|administrative\s\+\%(shutdown\|reset\)\|peer\s\+deconfigured\|connection\s\+\%(rejected\|collision\)\|configuration\s\+change\|out\s\+of\s\+resources\|setkey\|drop\|single\|double\)\>"
+syn match   bird2OspfPhraseKw "\<\%(link\s\+lsa\s\+suppression\|stub\s\+router\|graceful\s\+restart\s\+\%(aware\|time\)\|ecmp\s\+limit\|merge\s\+external\|rfc5838\|vpn\s\+pe\|instance\s\+id\|default\s\+\%(nssa\|cost2\?\)\|stub\s\+cost\|summary\|networks\|stubnet\|hidden\|translator\s\+stability\|virtual\s\+link\|transmit\s\+delay\|dead\s\+count\|poll\|type\s\+\%(bcast\|nbma\|pointopoint\|ptp\|ptmp\|pointomultipoint\)\|eligible\|real\s\+broadcast\|ptp\s\+\%(netmask\|address\)\|strict\s\+nonbroadcast\|rx\s\+buffer\s\+\%(normal\|large\)\|authentication\s\+simple\|show\s\+ospf\%(\s\+\%(interface\|neighbors\|topology\%(\s\+all\)\?\|state\%(\s\+all\)\?\|lsadb\%(\s\+\%(global\|area\|link\|type\|lsid\|self\|router\)\)\?\)\)\?\|ospf\s\+v[23]\|instance\|tag\|v2\|v3\|no\s\+summary\|real\s\+bdr\)\>"
+syn match   bird2RipPhraseKw "\<\%(rip\s\+ng\|mode\s\+\%(multicast\|broadcast\)\|version\s\+only\|check\s\+zero\|update\s\+time\|timeout\s\+time\|garbage\s\+time\|retransmit\s\+time\|split\s\+horizon\|poison\s\+reverse\|demand\s\+circuit\|ecmp\s\+\%(limit\|weight\)\|infinity\|show\s\+rip\s\+\%(interfaces\|neighbors\)\|ttl\s\+security\s\+tx\s\+only\|authentication\s\+\%(plaintext\|cryptographic\)\|honor\s\+neighbor\|honor\s\+always\)\>"
+syn match   bird2KernelPhraseKw "\<\%(merge\s\+paths\s\+limit\|merge\s\+paths\|kernel\s\+table\|netlink\s\+rx\s\+buffer\)\>"
 syn match   bird2PipePhraseKw "\<\%(mode\s\+\%(opaque\|transparent\|GRE\)\)\>"
+syn match   bird2StaticPhraseKw "\<\%(recursive\s\+mpls\|show\s\+static\|igp\s\+table\|check\s\+link\)\>"
+syn match   bird2AuthPhraseKw "\<\%(authentication\s\+\%(none\|mac\%(\s\+permissive\)\?\|md5\|ao\)\|generate\s\+from\|generate\s\+to\|accept\s\+from\|accept\s\+to\)\>"
+syn match   bird2ChannelLimitPhraseKw "\<\%(import\s\+limit\|export\s\+limit\)\>"
+syn match   bird2SocketPhraseKw "\<\%(tx\s\+class\|tx\s\+dscp\|tx\s\+priority\)\>"
+syn match   bird2InterfacePhraseKw "\<\%(rx\s\+buffer\|tx\s\+length\|check\s\+link\)\>"
+syn match   bird2DiagnosticsPhraseKw "\<\%(debug\s\+latency\s\+limit\|debug\s\+latency\|debug\s\+show\s\+route\|debug\s\+protocols\|debug\s\+channels\|debug\s\+tables\|debug\s\+commands\|debug\s\+all\|debug\s\+\%(events\|filters\|interfaces\|off\|packets\|routes\|states\)\|debug\|watchdog\s\+warning\|watchdog\s\+timeout\|states\|routes\|filters\|interfaces\|events\|packets\|messages\)\>"
+syn match   bird2TablePhraseKw "\<\%(min\s\+settle\s\+time\|max\s\+settle\s\+time\|gc\s\+threshold\|gc\s\+period\|export\s\+settle\s\+time\|sorted\|trie\|roa\)\>"
+syn match   bird2AggregatorPhraseKw "\<\%(peer\s\+table\|aggregate\s\+on\|merge\s\+by\)\>"
+syn match   bird2VpnPhraseKw "\<\%(route\s\+distinguisher\|import\s\+target\|export\s\+target\|route\s\+target\)\>"
+syn match   bird2EvpnPhraseKw "\<\%(encapsulation\s\+vxlan\|vlan\s\+filtering\|vlan\s\+range\|vni\|vid\|bridge\s\+device\|kbr\s\+source\|tunnel\s\+device\|router\s\+address\|evpn\s\+\%(ead\|mac\|imet\|es\)\|tag\)\>"
+syn match   bird2BmpPhraseKw "\<\%(monitoring\s\+rib\s\+in\s\+pre_policy\|monitoring\s\+rib\s\+in\s\+post_policy\|system\s\+description\|system\s\+name\|tx\s\+buffer\s\+limit\|station\s\+address\|station\)\>"
+syn match   bird2RadvPhraseKw "\<\%(solicited\s\+ra\s\+unicast\|router\s\+discovery\|min\s\+ra\s\+interval\|max\s\+ra\s\+interval\|min\s\+delay\|link\s\+mtu\|default\s\+lifetime\|route\s\+lifetime\|default\s\+preference\|route\s\+preference\|prefix\s\+linger\s\+time\|route\s\+linger\s\+time\|current\s\+hop\s\+limit\|propagate\s\+routes\|other\s\+config\|reachable\s\+time\|retrans\s\+timer\|valid\s\+lifetime\|preferred\s\+lifetime\|lifetime\s\+mult\|pd\s\+preferred\|rdnss\s\+local\|dnssl\s\+local\|custom\s\+option\s\+type\|custom\s\+option\s\+local\|managed\|trigger\|sensitive\|autonomous\|skip\|low\|medium\|high\)\>"
+syn match   bird2AspaPhraseKw "\<\%(aspa\s\+providers\|transit\s\+providers\|route\s\+aspa\)\>"
+syn match   bird2FlowspecPhraseKw "\<\%(next\s\+header\|icmp\s\+type\|icmp\s\+code\|tcp\s\+flags\)\>"
+syn match   bird2ThreadingPhraseKw "\<\%(thread\s\+group\|show\s\+threads\s\+all\|show\s\+threads\|cork\s\+threshold\|route\s\+refresh\s\+export\s\+settle\s\+time\|digest\s\+settle\s\+time\|filter\s\+stacks\|max\s\+generation\)\>"
+syn match   bird2MrtPhraseKw "\<\%(always\s\+add\s\+path\|filename\)\>"
+syn match   bird2PerfPhraseKw "\<\%(mode\s\+\%(import\|export\)\|exp\s\+\%(from\|to\)\|threshold\s\+\%(min\|max\)\|repeat\)\>"
+syn match   bird2OperationsPhraseKw "\<\%(router\s\+id\s\+from\|graceful\s\+restart\s\+wait\|vrf\s\+default\|receive\s\+limit\|import\s\+keep\s\+filtered\|export\s\+in\|rpki\s\+reload\|mrtdump\s\+protocols\)\>"
+syn match   bird2CliShowPhraseKw "\<\%(show\s\+status\|show\s\+protocols\s\+all\|show\s\+protocols\|show\s\+interfaces\s\+summary\|show\s\+interfaces\|show\s\+symbols\s\+\%(table\|filter\|function\|protocol\|template\|roa\)\|show\s\+symbols\|show\s\+route\s\+\%(for\|in\|table\|filter\|where\|all\|primary\|filtered\|import\|export\|exported\|preexport\|noexport\|protocol\|stats\|count\)\|show\s\+bfd\s\+sessions\s\+\%(address\|direct\|multihop\|interface\|dev\|all\|ipv4\|ipv6\)\|show\s\+bfd\s\+sessions\|show\s\+mpls\s\+ranges\|show\s\+memory\)\>"
+syn match   bird2CliReloadPhraseKw "\<\%(reload\s\+filters\s\+in\|reload\s\+filters\s\+out\|reload\s\+filters\|reload\s\+bgp\s\+in\|reload\s\+bgp\s\+out\|reload\s\+bgp\|reload\s\+in\|reload\s\+out\)\>"
+syn match   bird2CliReloadModifierKw "\<partial\>"
+syn match   bird2CliDumpPhraseKw "\<\%(dump\s\+tables\|dump\s\+attribute\s\+stats\|dump\s\+ao\s\+keys\|dump\s\+filter\s\+all\|dump\s\+resources\|dump\s\+sockets\|dump\s\+events\|dump\s\+interfaces\|dump\s\+neighbors\|dump\s\+attributes\|dump\s\+routes\|dump\s\+protocols\|mrt\s\+dump\s\+table\|mrt\s\+dump\s\+where\|mrt\s\+dump\s\+to\|mrt\s\+dump\s\+filter\|mrt\s\+dump\|timeformat\s\+route\|timeformat\s\+protocol\|timeformat\s\+base\|timeformat\s\+log\|timeformat\s\+iso\|configure\s\+soft\s\+timeout\|configure\s\+soft\|configure\s\+timeout\|configure\s\+confirm\|configure\s\+undo\|configure\s\+status\|configure\s\+check\|restrict\|echo\|enable\|disable\|restart\|mrtdump\|quit\|exit\|help\)\>"
+syn match   bird2CliControlPhraseKw "\<\%(configure\|down\|graceful\s\+restart\|timeformat\s\+\%(short\|long\|ms\|us\)\)\>"
 
 " ------------------------
 " Semantic Modifiers (repository.semantic-modifiers)
@@ -206,23 +237,26 @@ syn keyword bird2BuiltinFunc defined unset roa_check aspa_check aspa_check_downs
 " ------------------------
 " Method Properties (repository.method-properties)
 " ------------------------
-syn keyword bird2Property   first last last_nonaggregated len asn data data1 data2 is_v4 ip src dst rd maxlen type mask min max contained
+syn keyword bird2Property   first last last_nonaggregated len asn data data1 data2 is_v4 ip src dst rd maxlen type mask min max mac vlan_id evpn_type evpn_tag evpn_esi router_ip contained
 
 " ------------------------
 " Route Attributes (repository.route-attributes)
 " ------------------------
-syn keyword bird2RouteAttr  net scope preference from gw proto source dest ifname ifindex weight gw_mpls gw_mpls_stack onlink igp_metric mpls_label mpls_policy mpls_class bgp_path bgp_origin bgp_next_hop bgp_med bgp_local_pref bgp_community bgp_ext_community bgp_large_community bgp_originator_id bgp_cluster_list ospf_metric1 ospf_metric2 ospf_tag ospf_router_id rip_metric rip_tag mypath mylclist
+syn keyword bird2RouteAttr  net scope preference from gw proto source dest ifname ifindex weight gw_mpls gw_mpls_stack onlink igp_metric local_metric nexthop hostentry flowspec_valid aspa_providers roa_aggregated mpls_label mpls_policy mpls_class bgp_path bgp_origin bgp_next_hop bgp_med bgp_local_pref bgp_community bgp_ext_community bgp_large_community bgp_originator_id bgp_cluster_list bgp_atomic_aggr bgp_aggregator bgp_aigp bgp_pmsi_tunnel bgp_otc bgp_mpls_label_stack bgp_mp_reach_nlri bgp_mp_unreach_nlri bgp_as4_path bgp_as4_aggregator ospf_metric1 ospf_metric2 ospf_tag ospf_router_id rip_metric rip_tag rip_from babel_metric babel_router_id babel_seqno radv_preference radv_lifetime ra_preference ra_lifetime krt_source krt_metric krt_prefsrc krt_realm krt_scope krt_mtu krt_window krt_rtt krt_rttvar krt_ssthresh krt_sstresh krt_cwnd krt_advmss krt_reordering krt_hoplimit krt_initcwnd krt_rto_min krt_initrwnd krt_quickack krt_congctl krt_fastopen_no_cookie krt_lock_mtu krt_lock_window krt_lock_rtt krt_lock_rttvar krt_lock_ssthresh krt_lock_sstresh krt_lock_cwnd krt_lock_advmss krt_lock_reordering krt_lock_hoplimit krt_lock_initcwnd krt_lock_rto_min krt_lock_initrwnd krt_lock_quickack krt_lock_congctl krt_lock_fastopen_no_cookie krt_feature_allfrag krt_feature_ecn kbr_source iface_type iface_bridge_vlan_filtering iface_vxlan_id iface_vxlan_learning iface_vxlan_ip_addr mypath mylclist
+syn match   bird2RouteAttr  "\<bgp_unknown_0x[0-9a-fA-F]\{2}\>"
+syn keyword bird2RuntimeAttr proto_name proto_protocol_name proto_protocol_type proto_main_table_id proto_state proto_last_modified proto_info proto_proto_id ea_proto_channel_list proto_channel_id channel_in_keep rtable proto_bgp_rem_id proto_bgp_rem_as proto_bgp_loc_as proto_bgp_rem_ip bgp_afi bgp_peer_type bgp_extended_next_hop bgp_add_path_rx bgp_in_conn_local_open_msg bgp_in_conn_remote_open_msg bgp_out_conn_local_open_msg bgp_out_conn_remote_open_msg bgp_in_conn_state bgp_out_conn_state bgp_in_conn_sk bgp_out_conn_sk bgp_state_startup bgp_close_bmp bgp_as4_session bgp_as4_in_conn bgp_as4_out_conn
 
 " ------------------------
 " Data Types (repository.data-types)
 " ------------------------
-syn match   bird2Type       "\<\%(\%(int\|pair\|quad\|ip\|prefix\|ec\|lc\|rd\|enum\)\s\+set\|int\|bool\|ip\|prefix\|rd\|pair\|quad\|ec\|lc\|string\|bytestring\|bgpmask\|bgppath\|clist\|eclist\|lclist\|set\|enum\|route\)\>"
+syn match   bird2Type       "\<\%(\%(int\|pair\|quad\|ip\|prefix\|mac\|ec\|lc\|rd\|enum\)\s\+set\|int\|bool\|ip\|prefix\|mac\|rd\|pair\|quad\|ec\|lc\|string\|bytestring\|bgpmask\|bgppath\|clist\|eclist\|lclist\|set\|enum\|route\)\>"
 
 " ------------------------
 " Operators (repository.operators)
 " ------------------------
 syn match  bird2Comparison  "!\~\|==\|!=\|<=\|>=\|=\|<\|>\|\~"
 syn match  bird2Logical     "&&\|||\|->\|!"
+syn match  bird2Bitwise     "\%(&\)\@<!&\%(&\)\@!\|\%(|\)\@<!|\%(|\)\@!"
 syn match  bird2Concat      "++"
 syn match  bird2Range       "\.\."
 syn match  bird2Arithmetic  "\%(+\ze[^+]\|-\ze[^>]\|\*\|/\|%\)"
@@ -236,17 +270,25 @@ syn keyword bird2BoolConst  on off yes no true false
 " Special constants
 syn keyword bird2SpecialConst empty unknown generic rt ro one ten
 " Scope constants
-syn keyword bird2ScopeConst SCOPE_HOST SCOPE_LINK SCOPE_SITE SCOPE_ORGANIZATION SCOPE_UNIVERSE
+syn keyword bird2ScopeConst SCOPE_HOST SCOPE_LINK SCOPE_SITE SCOPE_ORGANIZATION SCOPE_UNIVERSE SCOPE_UNDEFINED
 " Source constants
-syn keyword bird2SourceConst RTS_STATIC RTS_INHERIT RTS_DEVICE RTS_RIP RTS_OSPF RTS_OSPF_IA RTS_OSPF_EXT1 RTS_OSPF_EXT2 RTS_BGP RTS_PIPE RTS_BABEL
+syn keyword bird2SourceConst RTS_STATIC RTS_INHERIT RTS_DEVICE RTS_STATIC_DEVICE RTS_REDIRECT RTS_RIP RTS_OSPF RTS_OSPF_IA RTS_OSPF_EXT1 RTS_OSPF_EXT2 RTS_BGP RTS_PIPE RTS_BABEL RTS_RPKI RTS_L3VPN RTS_AGGREGATED RTS_BRIDGE RTS_EVPN
 " Destination constants
-syn keyword bird2DestConst  RTD_ROUTER RTD_DEVICE RTD_MULTIPATH RTD_BLACKHOLE RTD_UNREACHABLE RTD_PROHIBIT
+syn keyword bird2DestConst  RTD_UNICAST RTD_ROUTER RTD_DEVICE RTD_MULTIPATH RTD_BLACKHOLE RTD_UNREACHABLE RTD_PROHIBIT
 " ROA constants
 syn keyword bird2RoaConst   ROA_UNKNOWN ROA_INVALID ROA_VALID
 " ASPA constants
 syn keyword bird2AspaConst  ASPA_UNKNOWN ASPA_INVALID ASPA_VALID
+" BGP origin constants
+syn keyword bird2BgpOriginConst ORIGIN_IGP ORIGIN_EGP ORIGIN_INCOMPLETE
+" RA preference constants
+syn keyword bird2RaPreferenceConst RA_PREF_LOW RA_PREF_MEDIUM RA_PREF_HIGH
+" Address family constants
+syn keyword bird2AddressFamilyConst AF_IPV4 AF_IPV6
+" Bridge source constants
+syn keyword bird2BridgeSourceConst KBR_SRC_BIRD KBR_SRC_LOCAL KBR_SRC_STATIC KBR_SRC_DYNAMIC
 " Net type constants
-syn keyword bird2NetConst   NET_IP4 NET_IP6 NET_IP6_SADR NET_VPN4 NET_VPN6 NET_ROA4 NET_ROA6 NET_FLOW4 NET_FLOW6 NET_MPLS
+syn keyword bird2NetConst   NET_IP4 NET_IP6 NET_IP6_SADR NET_VPN4 NET_VPN6 NET_ROA4 NET_ROA6 NET_FLOW4 NET_FLOW6 NET_MPLS NET_ASPA NET_ETH NET_EVPN NET_EVPN_EAD NET_EVPN_MAC NET_EVPN_IMET NET_EVPN_ES NET_NEIGHBOR
 " MPLS constants
 syn keyword bird2MplsConst  MPLS_POLICY_NONE MPLS_POLICY_STATIC MPLS_POLICY_PREFIX MPLS_POLICY_AGGREGATE MPLS_POLICY_VRF
 
@@ -274,12 +316,7 @@ syn match  bird2PropertyAccess "\.\s*[a-zA-Z_][a-zA-Z0-9_]*\%(\s*(\)\@!" contain
 " ------------------------
 " Variable Declarations (repository.variable-declarations)
 " ------------------------
-syn match  bird2VarDecl     "\<\%(\%(int\|pair\|quad\|ip\|prefix\|ec\|lc\|rd\|enum\)\s\+set\|int\|bool\|ip\|prefix\|rd\|pair\|quad\|ec\|lc\|string\|bytestring\|bgpmask\|bgppath\|clist\|eclist\|lclist\|set\|enum\|route\)\>\s\+[a-zA-Z_][a-zA-Z0-9_]*\s*\%(=\|;\)" contains=bird2Type,bird2Variable
-
-" ------------------------
-" Symbols/Variables (repository.symbols)
-" ------------------------
-syn match  bird2Variable    "[a-zA-Z_][a-zA-Z0-9_]*\>"
+syn match  bird2VarDecl     "\<\%(\%(int\|pair\|quad\|ip\|prefix\|mac\|ec\|lc\|rd\|enum\)\s\+set\|int\|bool\|ip\|prefix\|mac\|rd\|pair\|quad\|ec\|lc\|string\|bytestring\|bgpmask\|bgppath\|clist\|eclist\|lclist\|set\|enum\|route\)\>\s\+[a-zA-Z_][a-zA-Z0-9_]*\s*\%(=\|;\)" contains=bird2Type,bird2Variable
 
 " ------------------------
 " Blocks & Delimiters (repository.blocks)
@@ -289,7 +326,7 @@ syn match  bird2Delimiter   "[{}()\[\];,]"
 " ------------------------
 " Cluster for all patterns
 " ------------------------
-syn cluster bird2All contains=bird2Comment,bird2String,bird2QuotedSymbol,bird2Escape,bird2HexNumber,bird2Number,bird2TimeUnit,bird2IPv4,bird2IPv6,bird2VpnRD,bird2ByteString,bird2BgpPath,bird2BgpWildcard,bird2ASN,bird2Prefix,bird2FilterDef,bird2FunctionDef,bird2TemplateDef,bird2ProtocolDefWithTemplate,bird2ProtocolDefWithName,bird2ProtocolDefAnonymous,bird2NextHopIPv4,bird2NextHopIPv6,bird2NextHopSelf,bird2ExtendedNextHop,bird2NextHopPrefer,bird2NextHopKeep,bird2NextHopAddr,bird2RequireExtNexthop,bird2LocalAsStmt,bird2LocalAsTemplate,bird2NeighborStmt,bird2NeighborTemplate,bird2NeighborRange,bird2NeighborPort,bird2NeighborRole,bird2NeighborOnlink,bird2SourceAddress,bird2ImportFilter,bird2ImportFilterInline,bird2ExportWhere,bird2ExportFilter,bird2PrintStmt,bird2ControlFlow,bird2CaseElse,bird2FlowControl,bird2Structure,bird2ProtocolTypeKw,bird2RoutingKw,bird2InterfaceKw,bird2RpkiKw,bird2RpkiPhraseKw,bird2AuthKw,bird2TimeKw,bird2ConfigKw,bird2FlowspecKw,bird2AddressKw,bird2BfdPhraseKw,bird2BabelPhraseKw,bird2BgpPhraseKw,bird2OspfPhraseKw,bird2RipPhraseKw,bird2KernelPhraseKw,bird2PipePhraseKw,bird2SemanticModifier,bird2BuiltinFunc,bird2Property,bird2RouteAttr,bird2Type,bird2Comparison,bird2Logical,bird2Concat,bird2Arithmetic,bird2Range,bird2Accessor,bird2BoolConst,bird2SpecialConst,bird2ScopeConst,bird2SourceConst,bird2DestConst,bird2RoaConst,bird2AspaConst,bird2NetConst,bird2MplsConst,bird2FilterReference,bird2UserVariable,bird2FunctionCall,bird2MethodCall,bird2PropertyAccess,bird2VarDecl,bird2Variable,bird2Delimiter,bird2Keyword
+syn cluster bird2All contains=bird2Comment,bird2String,bird2QuotedSymbol,bird2Escape,bird2HexNumber,bird2Number,bird2TimeUnit,bird2IPv4,bird2IPv6,bird2VpnRD,bird2ByteString,bird2BgpPath,bird2BgpWildcard,bird2ASN,bird2Prefix,bird2FilterDef,bird2FunctionDef,bird2TemplateDef,bird2ProtocolDefWithTemplate,bird2ProtocolDefWithName,bird2ProtocolDefAnonymous,bird2NextHopIPv4,bird2NextHopIPv6,bird2NextHopSelf,bird2ExtendedNextHop,bird2NextHopPrefer,bird2NextHopKeep,bird2NextHopAddr,bird2RequireExtNexthop,bird2LocalAsStmt,bird2LocalAsTemplate,bird2NeighborStmt,bird2NeighborTemplate,bird2NeighborRange,bird2NeighborPort,bird2NeighborRole,bird2NeighborOnlink,bird2SourceAddress,bird2ImportFilter,bird2ImportFilterInline,bird2ExportWhere,bird2ExportPrefilter,bird2ExportFilter,bird2PrintStmt,bird2ControlFlow,bird2CaseElse,bird2FlowControl,bird2Structure,bird2ProtocolTypeKw,bird2RoutingKw,bird2DeviceKw,bird2InterfaceKw,bird2RpkiKw,bird2RpkiPhraseKw,bird2AuthKw,bird2TimeKw,bird2ConfigKw,bird2FlowspecKw,bird2AddressKw,bird2BfdPhraseKw,bird2BabelPhraseKw,bird2BgpPhraseKw,bird2OspfPhraseKw,bird2RipPhraseKw,bird2KernelPhraseKw,bird2PipePhraseKw,bird2StaticPhraseKw,bird2AuthPhraseKw,bird2ChannelLimitPhraseKw,bird2SocketPhraseKw,bird2InterfacePhraseKw,bird2DiagnosticsPhraseKw,bird2TablePhraseKw,bird2AggregatorPhraseKw,bird2VpnPhraseKw,bird2EvpnPhraseKw,bird2BmpPhraseKw,bird2RadvPhraseKw,bird2AspaPhraseKw,bird2FlowspecPhraseKw,bird2ThreadingPhraseKw,bird2MrtPhraseKw,bird2PerfPhraseKw,bird2OperationsPhraseKw,bird2CliShowPhraseKw,bird2CliReloadPhraseKw,bird2CliReloadModifierKw,bird2CliDumpPhraseKw,bird2CliControlPhraseKw,bird2SemanticModifier,bird2BuiltinFunc,bird2Property,bird2RouteAttr,bird2RuntimeAttr,bird2Type,bird2Comparison,bird2Logical,bird2Bitwise,bird2Concat,bird2Arithmetic,bird2Range,bird2Accessor,bird2BoolConst,bird2SpecialConst,bird2ScopeConst,bird2SourceConst,bird2DestConst,bird2RoaConst,bird2AspaConst,bird2BgpOriginConst,bird2RaPreferenceConst,bird2AddressFamilyConst,bird2BridgeSourceConst,bird2NetConst,bird2MplsConst,bird2FilterReference,bird2UserVariable,bird2FunctionCall,bird2MethodCall,bird2PropertyAccess,bird2VarDecl,bird2Variable,bird2Delimiter,bird2Keyword
 
 " ------------------------
 " Links to default highlight groups
@@ -348,6 +385,7 @@ hi def link bird2SourceAddress    Statement
 hi def link bird2ImportFilter     Statement
 hi def link bird2ImportFilterInline Statement
 hi def link bird2ExportWhere      Statement
+hi def link bird2ExportPrefilter  Statement
 hi def link bird2ExportFilter     Statement
 hi def link bird2PrintStmt        Statement
 
@@ -358,6 +396,7 @@ hi def link bird2Structure        Keyword
 hi def link bird2Keyword          Keyword
 hi def link bird2ProtocolTypeKw   Keyword
 hi def link bird2RoutingKw        Keyword
+hi def link bird2DeviceKw         Keyword
 hi def link bird2InterfaceKw      Keyword
 hi def link bird2RpkiKw           Keyword
 hi def link bird2RpkiPhraseKw     Keyword
@@ -373,15 +412,40 @@ hi def link bird2OspfPhraseKw     Keyword
 hi def link bird2RipPhraseKw      Keyword
 hi def link bird2KernelPhraseKw   Keyword
 hi def link bird2PipePhraseKw     Keyword
+hi def link bird2StaticPhraseKw   Keyword
+hi def link bird2AuthPhraseKw     Keyword
+hi def link bird2ChannelLimitPhraseKw Keyword
+hi def link bird2SocketPhraseKw   Keyword
+hi def link bird2InterfacePhraseKw Keyword
+hi def link bird2DiagnosticsPhraseKw Keyword
+hi def link bird2TablePhraseKw    Keyword
+hi def link bird2AggregatorPhraseKw Keyword
+hi def link bird2VpnPhraseKw      Keyword
+hi def link bird2EvpnPhraseKw     Keyword
+hi def link bird2BmpPhraseKw      Keyword
+hi def link bird2RadvPhraseKw     Keyword
+hi def link bird2AspaPhraseKw     Keyword
+hi def link bird2FlowspecPhraseKw Keyword
+hi def link bird2ThreadingPhraseKw Keyword
+hi def link bird2MrtPhraseKw      Keyword
+hi def link bird2PerfPhraseKw     Keyword
+hi def link bird2OperationsPhraseKw Keyword
+hi def link bird2CliShowPhraseKw  Keyword
+hi def link bird2CliReloadPhraseKw Keyword
+hi def link bird2CliReloadModifierKw Keyword
+hi def link bird2CliDumpPhraseKw  Keyword
+hi def link bird2CliControlPhraseKw Keyword
 hi def link bird2SemanticModifier Keyword
 
 hi def link bird2BuiltinFunc      Function
 hi def link bird2Property         Identifier
 hi def link bird2RouteAttr        Identifier
+hi def link bird2RuntimeAttr      Identifier
 hi def link bird2Type             Type
 
 hi def link bird2Comparison       Operator
 hi def link bird2Logical          Operator
+hi def link bird2Bitwise          Operator
 hi def link bird2Concat           Operator
 hi def link bird2Arithmetic       Operator
 hi def link bird2Range            Operator
@@ -394,6 +458,10 @@ hi def link bird2SourceConst      Constant
 hi def link bird2DestConst        Constant
 hi def link bird2RoaConst         Constant
 hi def link bird2AspaConst        Constant
+hi def link bird2BgpOriginConst   Constant
+hi def link bird2RaPreferenceConst Constant
+hi def link bird2AddressFamilyConst Constant
+hi def link bird2BridgeSourceConst Constant
 hi def link bird2NetConst         Constant
 hi def link bird2MplsConst        Constant
 

--- a/tests/ftdetect.vim
+++ b/tests/ftdetect.vim
@@ -1,0 +1,70 @@
+set nomore
+set shortmess+=I
+
+execute 'source ' . fnameescape(getcwd() . '/ftdetect/bird2.vim')
+
+function! s:CheckConf(lines, expected, label) abort
+  let l:path = tempname() . '.conf'
+  call writefile(a:lines, l:path)
+  execute 'edit ' . fnameescape(l:path)
+  call assert_equal(a:expected, &l:filetype, a:label)
+  bwipeout!
+  call delete(l:path)
+endfunction
+
+function! s:CheckNamed(filename, expected, label) abort
+  let l:directory = tempname()
+  call mkdir(l:directory, 'p')
+  let l:path = l:directory . '/' . a:filename
+  call writefile(['# filename detection'], l:path)
+  execute 'edit ' . fnameescape(l:path)
+  call assert_equal(a:expected, &l:filetype, a:label)
+  bwipeout!
+  call delete(l:path)
+  call delete(l:directory, 'd')
+endfunction
+
+call s:CheckNamed('bird2.conf', 'bird2', 'exact BIRD filename is detected')
+call s:CheckNamed('bluebird.conf', '', 'unrelated filename is not detected')
+
+call s:CheckConf(['protocol evpn fabric {'], 'bird2', 'latest protocol is strong evidence')
+call s:CheckConf(['protocol aggregator aggregate_routes {'], 'bird2', 'aggregator is detected')
+call s:CheckConf(['table users {'], '', 'one generic table is insufficient')
+call s:CheckConf(
+  \ ['filter import_filter {', '  export all;'],
+  \ 'bird2',
+  \ 'two independent policy signals are sufficient',
+  \ )
+
+let g:bird2_heuristic_detect = 0
+call s:CheckConf(['protocol bgp upstream {'], '', 'heuristic detection can be disabled')
+unlet g:bird2_heuristic_detect
+
+call s:CheckConf(
+  \ repeat(['# ordinary configuration'], 200) + ['protocol bgp too_late {'],
+  \ '',
+  \ 'heuristic scan is bounded to 200 lines',
+  \ )
+
+new
+setlocal filetype=json
+call setline(1, ['protocol bgp upstream {'])
+doautocmd BufRead preserved.conf
+call assert_equal('json', &l:filetype, 'non-conf filetypes are preserved')
+bwipeout!
+
+new
+setlocal filetype=conf
+call setline(1, ['protocol bridge fabric {'])
+doautocmd BufRead upgraded.conf
+call assert_equal('bird2', &l:filetype, 'generic conf filetype is upgraded')
+bwipeout!
+
+if !empty(v:errors)
+  for error in v:errors
+    echomsg error
+  endfor
+  cquit
+endif
+
+qa!

--- a/tests/ftdetect.vim
+++ b/tests/ftdetect.vim
@@ -29,6 +29,10 @@ call s:CheckNamed('bluebird.conf', '', 'unrelated filename is not detected')
 
 call s:CheckConf(['protocol evpn fabric {'], 'bird2', 'latest protocol is strong evidence')
 call s:CheckConf(['protocol aggregator aggregate_routes {'], 'bird2', 'aggregator is detected')
+call s:CheckConf(['ipv6 sadr table source_specific;'], 'bird2', 'source-specific table is detected')
+call s:CheckConf(['eth table layer2_routes;'], 'bird2', 'Ethernet table is detected')
+call s:CheckConf(['neighbor table peers;'], 'bird2', 'neighbor table is detected')
+call s:CheckConf(['ipv4-mpls table labels;'], '', 'address-family label is not a table type')
 call s:CheckConf(['table users {'], '', 'one generic table is insufficient')
 call s:CheckConf(
   \ ['filter import_filter {', '  export all;'],
@@ -58,6 +62,20 @@ setlocal filetype=conf
 call setline(1, ['protocol bridge fabric {'])
 doautocmd BufRead upgraded.conf
 call assert_equal('bird2', &l:filetype, 'generic conf filetype is upgraded')
+bwipeout!
+
+new
+setlocal filetype=conf
+call setline(1, ['protocol evpn fabric {'])
+doautocmd FileType conf
+call assert_equal('bird2', &l:filetype, 'FileType conf fallback upgrades the buffer')
+bwipeout!
+
+new
+setlocal filetype=conf
+call setline(1, ['protocol bridge fabric {'])
+doautocmd BufWritePost saved.conf
+call assert_equal('bird2', &l:filetype, 'BufWritePost upgrades newly populated configs')
 bwipeout!
 
 if !empty(v:errors)

--- a/tests/ftplugin.vim
+++ b/tests/ftplugin.vim
@@ -1,0 +1,33 @@
+set nomore
+let mapleader = ','
+
+new
+call setline(1, ['protocol bgp upstream {', '  ipv4;', '}'])
+execute 'source ' . fnameescape(getcwd() . '/ftplugin/bird2.vim')
+
+call assert_equal('# %s', &l:commentstring, 'comment string')
+call assert_equal(':#', &l:comments, 'comments option')
+call assert_equal('syntaxcomplete#Complete', &l:omnifunc, 'syntax completion')
+call assert_match('<SNR>\d\+_ToggleCommentLine', maparg('<Plug>Bird2Comment', 'n'), 'normal plug mapping')
+call assert_match('<SNR>\d\+_ToggleCommentRange', maparg('<Plug>Bird2Comment', 'x'), 'visual plug mapping')
+
+call feedkeys("\<Plug>Bird2Comment", 'xt')
+call assert_equal('# protocol bgp upstream {', getline(1), 'normal comment mapping')
+call feedkeys("\<Plug>Bird2Comment", 'xt')
+call assert_equal('protocol bgp upstream {', getline(1), 'normal uncomment mapping')
+bwipeout!
+
+new
+nnoremap <buffer> <Leader>c :let g:bird2_preserved_mapping = 1<CR>
+execute 'source ' . fnameescape(getcwd() . '/ftplugin/bird2.vim')
+call assert_match('bird2_preserved_mapping', maparg('<Leader>c', 'n'), 'existing leader mapping is preserved')
+bwipeout!
+
+if !empty(v:errors)
+  for error in v:errors
+    echomsg error
+  endfor
+  cquit
+endif
+
+qa!

--- a/tests/syntax.vim
+++ b/tests/syntax.vim
@@ -12,6 +12,9 @@ call setline(1, [
   \ 'kbr_source = KBR_SRC_DYNAMIC;',
   \ 'debug events;',
   \ 'trie yes;',
+  \ 'if bt_check_assign(net, 1) then accept;',
+  \ 'route net = 10.0.0.0/8{16,24};',
+  \ 'route net = ::/0;',
   \ ])
 
 function! s:Group(line, needle) abort
@@ -31,6 +34,10 @@ call assert_equal('bird2AddressFamilyConst', s:Group(5, 'AF_IPV6'), 'address fam
 call assert_equal('bird2BridgeSourceConst', s:Group(6, 'KBR_SRC_DYNAMIC'), 'bridge enum')
 call assert_equal('bird2DiagnosticsPhraseKw', s:Group(7, 'debug'), 'debug CLI phrase')
 call assert_equal('bird2TablePhraseKw', s:Group(8, 'trie'), 'trie table option')
+call assert_equal('bird2BuiltinFunc', s:Group(9, 'bt_check_assign'), 'BIRD test builtin')
+call assert_equal('bird2Prefix', s:Group(10, '10.0.0.0/8{16,24}'), 'IPv4 prefix range')
+call assert_equal('bird2Prefix', s:Group(10, '{16,24}'), 'IPv4 prefix range suffix')
+call assert_equal('bird2Prefix', s:Group(11, '::/0'), 'compressed IPv6 prefix')
 
 if !empty(v:errors)
   for error in v:errors

--- a/tests/syntax.vim
+++ b/tests/syntax.vim
@@ -1,0 +1,42 @@
+set nomore
+syntax enable
+
+new
+execute 'source ' . fnameescape(getcwd() . '/syntax/bird2.vim')
+call setline(1, [
+  \ 'mac set allowed = [ 02:00:00:00:00:01 ];',
+  \ 'int flags = (ifindex | 2) & 7;',
+  \ 'if ready && enabled || fallback then accept;',
+  \ 'local_metric = bgp_unknown_0x2a;',
+  \ 'proto_protocol_type = AF_IPV6;',
+  \ 'kbr_source = KBR_SRC_DYNAMIC;',
+  \ 'debug events;',
+  \ 'trie yes;',
+  \ ])
+
+function! s:Group(line, needle) abort
+  let l:column = stridx(getline(a:line), a:needle) + 1
+  return synIDattr(synID(a:line, l:column, 1), 'name')
+endfunction
+
+call assert_equal('bird2Type', s:Group(1, 'mac set'), 'mac set type')
+call assert_equal('bird2Bitwise', s:Group(2, '|'), 'bitwise or')
+call assert_equal('bird2Bitwise', s:Group(2, '&'), 'bitwise and')
+call assert_equal('bird2Logical', s:Group(3, '&&'), 'logical and remains intact')
+call assert_equal('bird2Logical', s:Group(3, '||'), 'logical or remains intact')
+call assert_equal('bird2RouteAttr', s:Group(4, 'local_metric'), 'BIRD 3 local metric')
+call assert_equal('bird2RouteAttr', s:Group(4, 'bgp_unknown_0x2a'), 'unknown BGP attr')
+call assert_equal('bird2RuntimeAttr', s:Group(5, 'proto_protocol_type'), 'runtime attr')
+call assert_equal('bird2AddressFamilyConst', s:Group(5, 'AF_IPV6'), 'address family enum')
+call assert_equal('bird2BridgeSourceConst', s:Group(6, 'KBR_SRC_DYNAMIC'), 'bridge enum')
+call assert_equal('bird2DiagnosticsPhraseKw', s:Group(7, 'debug'), 'debug CLI phrase')
+call assert_equal('bird2TablePhraseKw', s:Group(8, 'trie'), 'trie table option')
+
+if !empty(v:errors)
+  for error in v:errors
+    echomsg error
+  endfor
+  cquit
+endif
+
+qa!


### PR DESCRIPTION
## Status

Merged on 2026-07-17 as commit `42db3760917de0463136908dcb91e477c54cdadf`. The full Vim compatibility matrix passed on the merge commit, and version `1.0.13` is production-ready.

## Changes

- Align the Vim syntax snapshot with BIRD 2.19 and BIRD 3.3, versioned `1.0.13-20260717`.
- Cover current and rare CLI phrases, enum constants, route/runtime/interface attributes, `mac` types, `bt_check_assign`, and collision-safe bitwise operators.
- Bound IPv6 prefix matching, support compressed `::/0`, and correctly highlight IPv4 `{min,max}` suffixes.
- Move the generic identifier rule earlier so specialized syntax groups keep priority.
- Replace broad filename matching with exact BIRD filename/path patterns.
- Add bounded, comment-aware heuristic detection with immediate strong signals and two-signal fallback matching.
- Align typed table detection with upstream syntax: `eth table`, `neighbor table`, and `ipv6 sadr table`, while rejecting address-family labels that are not table declarations.
- Preserve unrelated filetypes and add `FileType conf` plus `BufWritePost` upgrades for late-populated generic configs.
- Provide working buffer-local comment mappings, preserve user `<Leader>c` mappings, and keep ftplugin cleanup reversible.

## Three review rounds

1. Syntax and security review fixed prefix-range behavior and added the missing BIRD test builtin.
2. Edge-case review corrected real typed-table heuristics and added write-time / generic-conf fallback detection.
3. Final review reran every runtime test, actionlint, matrix CI, mirror hashing, and a complete final security diff scan with zero findings.

## Validation

- Headless syntax source check
- Syntax-group assertions for `mac set`, bitwise/logical operators, current attributes, enum constants, `bt_check_assign`, compressed IPv6, and prefix ranges
- Filetype tests for exact filenames, false-positive avoidance, valid/invalid typed tables, scoring, opt-out, 200-line bounds, `FileType conf`, `BufWritePost`, and filetype preservation
- Filetype-plugin tests for options, working comment mappings, and user mapping preservation
- `actionlint .github/workflows/vim.yml`
- `bash -n scripts/install.sh`
- `git diff --check`
- Final security diff scan: zero findings, no deferred units
- Final syntax SHA-256: `c19288047ab7d9567b52d3b316019c88ebeea3d723e1297ba798e62330e8f88a`

## CI

- [Vim compatibility run 29548708442](https://github.com/bird-chinese-community/BIRD2.vim/actions/runs/29548708442): Vim `v8.2.0000` and stable both succeeded

## Related PRs

- Canonical grammar: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/pull/14 (merged)
- Neovim mirror: https://github.com/bird-chinese-community/BIRD2.nvim/pull/1 (merged)


