### PR TITLE
docs: rename plugin to BIRD.vim and add update guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,14 @@ GitHub redirects the former `BIRD2.vim` repository URL, so existing checkouts co
 :PluginUpdate
 ```
 
-For a native package checkout:
+For an existing native package checkout, rename its directory, update the
+remote, and then pull the latest version:
 
 ```bash
+mv ~/.vim/pack/plugins/start/bird2.vim \
+  ~/.vim/pack/plugins/start/BIRD.vim
+git -C ~/.vim/pack/plugins/start/BIRD.vim remote set-url origin \
+  https://github.com/bird-chinese-community/BIRD.vim.git
 git -C ~/.vim/pack/plugins/start/BIRD.vim pull --ff-only
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bird2.vim
+# BIRD.vim
 
 <div align="center">
 
@@ -13,9 +13,12 @@ English | [简体中文](README.zh-CN.md)
 
 ## Overview
 
-`bird2.vim` provides Vim syntax highlighting, filetype detection, and filetype plugin support for BIRD 2 and BIRD 3 configuration files.
+`BIRD.vim` provides Vim syntax highlighting, filetype detection, and filetype plugin support for BIRD 2 and BIRD 3 configuration files.
 
 This is the Vim plugin component of the [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) project by the BIRD Chinese Community.
+
+> [!NOTE]
+> This repository was renamed from `BIRD2.vim` to reflect support for both BIRD 2 and BIRD 3. GitHub redirects the old URL, while the `bird2` filetype, runtime filenames, mappings, and configuration variables remain compatible.
 
 ## Features
 
@@ -29,34 +32,61 @@ This is the Vim plugin component of the [BIRD-tm-language-grammar](https://githu
 ### Using vim-plug
 
 ```vim
-Plug 'bird-chinese-community/bird2.vim'
+Plug 'bird-chinese-community/BIRD.vim'
 ```
 
 ### Using Vundle
 
 ```vim
-Plugin 'bird-chinese-community/bird2.vim'
+Plugin 'bird-chinese-community/BIRD.vim'
 ```
 
 ### Using pack.nvim (Neovim/Vim 8+)
 
 ```vim
-packadd! bird2.vim
+packadd! BIRD.vim
 ```
 
 Or manually clone to your pack directory:
 
 ```bash
-git clone https://github.com/bird-chinese-community/bird2.vim \
-  ~/.vim/pack/plugins/start/bird2.vim
+git clone https://github.com/bird-chinese-community/BIRD.vim \
+  ~/.vim/pack/plugins/start/BIRD.vim
 ```
 
 ### Manual Installation
 
 ```bash
-git clone https://github.com/bird-chinese-community/bird2.vim.git
-cd bird2.vim
+git clone https://github.com/bird-chinese-community/BIRD.vim.git
+cd BIRD.vim
 bash scripts/install.sh
+```
+
+## Updating
+
+GitHub redirects the former `BIRD2.vim` repository URL, so existing checkouts continue to fetch. Update the repository name in your plugin-manager configuration, then refresh it:
+
+```vim
+" vim-plug
+:PlugUpdate BIRD.vim
+
+" Vundle
+:PluginUpdate
+```
+
+For a native package checkout:
+
+```bash
+git -C ~/.vim/pack/plugins/start/BIRD.vim pull --ff-only
+```
+
+For an existing manual checkout that still uses the old directory name, update its remote and rerun the installer:
+
+```bash
+git -C /path/to/bird2.vim remote set-url origin \
+  https://github.com/bird-chinese-community/BIRD.vim.git
+git -C /path/to/bird2.vim pull --ff-only
+bash /path/to/bird2.vim/scripts/install.sh
 ```
 
 ## Filetype Detection
@@ -114,7 +144,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## Related Projects
 
 - [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) - TextMate grammar for BIRD 2 and BIRD 3
-- [bird2.nvim](https://github.com/bird-chinese-community/bird2.nvim) - Neovim plugin
+- [BIRD.nvim](https://github.com/bird-chinese-community/BIRD.nvim) - Neovim plugin
 - [vscode-bird2](https://github.com/bird-chinese-community/vscode-bird2-conf) - VS Code extension
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ git -C ~/.vim/pack/plugins/start/BIRD.vim remote set-url origin \
 git -C ~/.vim/pack/plugins/start/BIRD.vim pull --ff-only
 ```
 
-For an existing manual checkout that still uses the old directory name, update its remote and rerun the installer:
+For a manual checkout at another path, the directory name can remain unchanged;
+update its remote and rerun the installer:
 
 ```bash
 git -C /path/to/bird2.vim remote set-url origin \

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -84,7 +84,7 @@ git -C ~/.vim/pack/plugins/start/BIRD.vim remote set-url origin \
 git -C ~/.vim/pack/plugins/start/BIRD.vim pull --ff-only
 ```
 
-如果现有手动 checkout 仍使用旧目录名，可更新 remote 后重新运行安装器：
+对于位于其他路径的手动 checkout，目录名可保持不变；更新 remote 后重新运行安装器：
 
 ```bash
 git -C /path/to/bird2.vim remote set-url origin \

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-# bird2.vim
+# BIRD.vim
 
 <div align="center">
 
@@ -13,9 +13,12 @@
 
 ## 概述
 
-`bird2.vim` 为 BIRD 2 与 BIRD 3 配置文件提供 Vim 语法高亮、文件类型检测和文件类型插件支持。
+`BIRD.vim` 为 BIRD 2 与 BIRD 3 配置文件提供 Vim 语法高亮、文件类型检测和文件类型插件支持。
 
 这是 [BIRD 中文社区](https://github.com/bird-chinese-community) 的 [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) 项目的 Vim 插件组件。
+
+> [!NOTE]
+> 本仓库已从 `BIRD2.vim` 更名为 `BIRD.vim`，以体现同时支持 BIRD 2 与 BIRD 3。GitHub 会重定向旧 URL；`bird2` filetype、运行时文件名、映射和配置变量继续保持兼容。
 
 ## 功能特性
 
@@ -29,34 +32,61 @@
 ### 使用 vim-plug
 
 ```vim
-Plug 'bird-chinese-community/bird2.vim'
+Plug 'bird-chinese-community/BIRD.vim'
 ```
 
 ### 使用 Vundle
 
 ```vim
-Plugin 'bird-chinese-community/bird2.vim'
+Plugin 'bird-chinese-community/BIRD.vim'
 ```
 
 ### 使用 pack.nvim (Neovim/Vim 8+)
 
 ```vim
-packadd! bird2.vim
+packadd! BIRD.vim
 ```
 
 或手动克隆到 pack 目录：
 
 ```bash
-git clone https://github.com/bird-chinese-community/bird2.vim \
-  ~/.vim/pack/plugins/start/bird2.vim
+git clone https://github.com/bird-chinese-community/BIRD.vim \
+  ~/.vim/pack/plugins/start/BIRD.vim
 ```
 
 ### 手动安装
 
 ```bash
-git clone https://github.com/bird-chinese-community/bird2.vim.git
-cd bird2.vim
+git clone https://github.com/bird-chinese-community/BIRD.vim.git
+cd BIRD.vim
 bash scripts/install.sh
+```
+
+## 更新
+
+GitHub 会重定向原 `BIRD2.vim` 仓库 URL，因此现有 checkout 仍可继续拉取。建议先把插件管理器配置中的仓库名改为新名称，再执行更新：
+
+```vim
+" vim-plug
+:PlugUpdate BIRD.vim
+
+" Vundle
+:PluginUpdate
+```
+
+使用原生 package checkout 时：
+
+```bash
+git -C ~/.vim/pack/plugins/start/BIRD.vim pull --ff-only
+```
+
+如果现有手动 checkout 仍使用旧目录名，可更新 remote 后重新运行安装器：
+
+```bash
+git -C /path/to/bird2.vim remote set-url origin \
+  https://github.com/bird-chinese-community/BIRD.vim.git
+git -C /path/to/bird2.vim pull --ff-only
+bash /path/to/bird2.vim/scripts/install.sh
 ```
 
 ## 文件类型检测
@@ -114,7 +144,7 @@ autocmd BufRead,BufNewFile *.myext setfiletype bird2
 ## 相关项目
 
 - [BIRD-tm-language-grammar](https://github.com/bird-chinese-community/bird-tm-language-grammar) - BIRD 2 与 BIRD 3 的 TextMate 语法
-- [bird2.nvim](https://github.com/bird-chinese-community/bird2.nvim) - Neovim 插件
+- [BIRD.nvim](https://github.com/bird-chinese-community/BIRD.nvim) - Neovim 插件
 - [vscode-bird2](https://github.com/bird-chinese-community/vscode-bird2-conf) - VS Code 扩展
 
 ## 鸣谢

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,9 +74,13 @@ GitHub 会重定向原 `BIRD2.vim` 仓库 URL，因此现有 checkout 仍可继�
 :PluginUpdate
 ```
 
-使用原生 package checkout 时：
+如果现有原生 package checkout 仍使用旧目录名，请重命名目录、更新 remote，再拉取最新版本：
 
 ```bash
+mv ~/.vim/pack/plugins/start/bird2.vim \
+  ~/.vim/pack/plugins/start/BIRD.vim
+git -C ~/.vim/pack/plugins/start/BIRD.vim remote set-url origin \
+  https://github.com/bird-chinese-community/BIRD.vim.git
 git -C ~/.vim/pack/plugins/start/BIRD.vim pull --ff-only
 ```
 

--- a/doc/bird2.txt
+++ b/doc/bird2.txt
@@ -1,4 +1,4 @@
-*bird2.txt*	BIRD2 Configuration Syntax for Vim
+*bird2.txt*	BIRD Configuration Syntax for Vim
 
 Author:  BIRD Chinese Community <dev-bird@xmsl.dev>
 License: MPL-2.0
@@ -9,18 +9,19 @@ CONTENTS					*bird2-contents*
 
     1. Introduction ................ |bird2-introduction|
     2. Installation ................ |bird2-installation|
-    3. Filetype Detection ......... |bird2-filetype-detection|
-    4. Configuration ............... |bird2-configuration|
-    5. Syntax Highlighting ........ |bird2-syntax|
-    6. Commands .................... |bird2-commands|
-    7. Mappings .................... |bird2-mappings|
-    8. Related Projects ............ |bird2-related|
-    9. Changelog ................... |bird2-changelog|
+    3. Updating ..................... |bird2-updating|
+    4. Filetype Detection ......... |bird2-filetype-detection|
+    5. Configuration ............... |bird2-configuration|
+    6. Syntax Highlighting ........ |bird2-syntax|
+    7. Commands .................... |bird2-commands|
+    8. Mappings .................... |bird2-mappings|
+    9. Related Projects ............ |bird2-related|
+   10. Changelog ................... |bird2-changelog|
 
 ==============================================================================
 INTRODUCTION					*bird2-introduction*
 
-The bird2.vim plugin provides syntax highlighting and filetype detection for
+The BIRD.vim plugin provides syntax highlighting and filetype detection for
 BIRD 2 and BIRD 3 (BIRD Internet Routing Daemon) configuration files.
 
 BIRD is a dynamic IP routing daemon supporting IPv4 and IPv6 protocols,
@@ -38,27 +39,27 @@ INSTALLATION					*bird2-installation*
 VIM-PLUG ~
 
 	Add to your .vimrc: >
-		Plug 'bird-chinese-community/bird2.vim'
+		Plug 'bird-chinese-community/BIRD.vim'
 <
 
 VUNDLE ~
 
 	Add to your .vimrc: >
-		Plugin 'bird-chinese-community/bird2.vim'
+		Plugin 'bird-chinese-community/BIRD.vim'
 <
 
 PACK.NVIM (Vim 8+ / Neovim) ~
 
 	Clone to your pack directory: >
-		git clone https://github.com/bird-chinese-community/bird2.vim \
-		  ~/.vim/pack/plugins/start/bird2.vim
+		git clone https://github.com/bird-chinese-community/BIRD.vim \
+		  ~/.vim/pack/plugins/start/BIRD.vim
 <
 
 MANUAL ~
 
 	Run the install script: >
-		git clone https://github.com/bird-chinese-community/bird2.vim
-		cd bird2.vim
+		git clone https://github.com/bird-chinese-community/BIRD.vim
+		cd BIRD.vim
 		bash scripts/install.sh
 <
 
@@ -67,9 +68,35 @@ After installation, generate help tags: >
 <
 
 ==============================================================================
+UPDATING					*bird2-updating*
+
+BIRD.vim was renamed from BIRD2.vim. GitHub redirects the old repository URL,
+and the bird2 filetype, runtime filenames, mappings, and variables remain
+compatible. Update the repository name in your plugin-manager configuration.
+
+vim-plug: >
+	:PlugUpdate BIRD.vim
+<
+
+Vundle: >
+	:PluginUpdate
+<
+
+Native package: >
+	git -C ~/.vim/pack/plugins/start/BIRD.vim pull --ff-only
+<
+
+For an existing checkout using the old directory name: >
+	git -C /path/to/bird2.vim remote set-url origin \
+	  https://github.com/bird-chinese-community/BIRD.vim.git
+	git -C /path/to/bird2.vim pull --ff-only
+	bash /path/to/bird2.vim/scripts/install.sh
+<
+
+==============================================================================
 FILETYPE DETECTION				*bird2-filetype-detection*
 
-The plugin automatically detects BIRD2 configuration files by:
+The plugin automatically detects BIRD 2 and BIRD 3 configuration files by:
 
 EXTENSIONS ~
 	*.bird, *.bird2, *.bird3, *.bird.conf, *.bird2.conf, *.bird3.conf
@@ -149,9 +176,9 @@ BIRD-tm-language-grammar ~
 	TextMate grammar for BIRD2
 	https://github.com/bird-chinese-community/bird-tm-language-grammar
 
-bird2.nvim ~
+BIRD.nvim ~
 	Neovim plugin with Lua support
-	https://github.com/bird-chinese-community/bird2.nvim
+	https://github.com/bird-chinese-community/BIRD.nvim
 
 vscode-bird2 ~
 	VS Code extension

--- a/doc/bird2.txt
+++ b/doc/bird2.txt
@@ -82,7 +82,11 @@ Vundle: >
 	:PluginUpdate
 <
 
-Native package: >
+Native package (rename the old directory and update its remote): >
+	mv ~/.vim/pack/plugins/start/bird2.vim \
+	  ~/.vim/pack/plugins/start/BIRD.vim
+	git -C ~/.vim/pack/plugins/start/BIRD.vim remote set-url origin \
+	  https://github.com/bird-chinese-community/BIRD.vim.git
 	git -C ~/.vim/pack/plugins/start/BIRD.vim pull --ff-only
 <
 

--- a/doc/bird2.txt
+++ b/doc/bird2.txt
@@ -90,7 +90,7 @@ Native package (rename the old directory and update its remote): >
 	git -C ~/.vim/pack/plugins/start/BIRD.vim pull --ff-only
 <
 
-For an existing checkout using the old directory name: >
+For a manual checkout at another path (the directory name may stay): >
 	git -C /path/to/bird2.vim remote set-url origin \
 	  https://github.com/bird-chinese-community/BIRD.vim.git
 	git -C /path/to/bird2.vim pull --ff-only

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,15 +12,15 @@ else
   BOLD=""; RESET=""; BLUE=""; GREEN=""; YELLOW=""; RED=""
 fi
 
-info() { echo -e "${BLUE}[bird2.vim]${RESET} $*"; }
-ok()   { echo -e "${GREEN}[bird2.vim]${RESET} $*"; }
-warn() { echo -e "${YELLOW}[bird2.vim]${RESET} $*"; }
-err()  { echo -e "${RED}[bird2.vim]${RESET} $*" >&2; }
+info() { echo -e "${BLUE}[BIRD.vim]${RESET} $*"; }
+ok()   { echo -e "${GREEN}[BIRD.vim]${RESET} $*"; }
+warn() { echo -e "${YELLOW}[BIRD.vim]${RESET} $*"; }
+err()  { echo -e "${RED}[BIRD.vim]${RESET} $*" >&2; }
 
 usage() {
   cat <<'EOF'
 Usage: scripts/install.sh [--vim-dir PATH]
-Install bird2.vim to your Vim runtime directory.
+Install BIRD.vim to your Vim runtime directory.
 
 Options:
   --vim-dir PATH    Specify custom Vim directory (default: ~/.vim)
@@ -41,7 +41,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-info "Installing bird2.vim to ${YELLOW}$VIM_HOME${RESET}..."
+info "Installing BIRD.vim to ${YELLOW}$VIM_HOME${RESET}..."
 
 # Create directories
 mkdir -p "$VIM_HOME/syntax" "$VIM_HOME/ftdetect" "$VIM_HOME/ftplugin" "$VIM_HOME/doc"


### PR DESCRIPTION
## Status

The GitHub repository has been renamed to `BIRD.vim`. Review feedback is resolved and CI is green.

## Changes

- Rebrand the user-facing plugin name from `BIRD2.vim` to `BIRD.vim` for BIRD 2 and BIRD 3 support.
- Add English, Simplified Chinese, and Vim help update guides for vim-plug, Vundle, native packages, and existing manual checkouts.
- Document the GitHub redirect from the former repository URL.
- Add explicit native-package directory rename, remote migration, and pull steps in response to review feedback.
- Keep the `bird2` filetype, runtime filenames, mappings, and configuration variables unchanged for compatibility.
- Align installer output and related-project links with the new plugin name.

## Validation

- Vim syntax source check
- Syntax, filetype detection, and ftplugin regression suites
- Isolated `:helptags` generation
- `bash -n scripts/install.sh`
- `shellcheck scripts/install.sh`
- `actionlint`
- `git diff --check`
