### PR TITLE
Add bilingual changelog and change fragments

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -25,9 +25,9 @@ category: fixed
 
 - 🐛 **中文标题** / **English title**
 
-中文说明。
+  中文说明。
 
-English summary.
+  English summary.
 ```
 
 Supported bumps are `patch`, `minor`, and `major`. Supported categories are
@@ -41,8 +41,9 @@ node scripts/changeset.mjs check
 node scripts/changeset.mjs status
 ```
 
-CI runs `check` automatically. `status` lists pending fragments and reports the
-highest requested bump.
+CI runs `check` automatically. It validates the emoji, bilingual title,
+two-space paragraph indentation, and Chinese/English paragraph order. `status`
+lists pending fragments and reports the highest requested bump.
 
 To preview the notes for a version that is already in the changelog:
 

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,74 @@
+# Change fragments
+
+This repository uses a small, dependency-free change-fragment workflow inspired
+by the Changesets setup in BIRD-LSP. It keeps release notes reviewable in pull
+requests without introducing an npm package solely for release tooling.
+
+## Add a fragment
+
+Create a kebab-case fragment name and select its semantic-version bump and
+category:
+
+```sh
+node scripts/changeset.mjs new bright-birds patch fixed
+```
+
+Edit the generated file and replace both placeholder paragraphs. Release notes
+use the BIRD-LSP style: a bilingual title, followed by a Simplified Chinese
+paragraph and an English paragraph.
+
+```md
+---
+bump: patch
+category: fixed
+---
+
+- 🐛 **中文标题** / **English title**
+
+中文说明。
+
+English summary.
+```
+
+Supported bumps are `patch`, `minor`, and `major`. Supported categories are
+listed in `config.json`. Add a fragment for any user-visible or release-worthy
+change; purely internal test or CI maintenance may omit one.
+
+## Check pending changes
+
+```sh
+node scripts/changeset.mjs check
+node scripts/changeset.mjs status
+```
+
+CI runs `check` automatically. `status` lists pending fragments and reports the
+highest requested bump.
+
+To preview the notes for a version that is already in the changelog:
+
+```sh
+node scripts/changeset.mjs notes 1.0.13
+```
+
+Use inline Markdown links in fragments so extracted GitHub Release notes remain
+self-contained.
+
+## Prepare a release
+
+1. Inspect the pending fragments with `status`.
+2. Choose the next plugin version, synchronize the canonical syntax snapshot,
+   and update any version references in `doc/bird2.txt` as appropriate.
+3. Preview the generated changelog section:
+
+   ```sh
+   node scripts/changeset.mjs release 1.0.14 \
+     --date 2026-07-18 --dry-run
+   ```
+
+4. Run the same command without `--dry-run`. It inserts the new bilingual
+   section in `CHANGELOG.md` and deletes the consumed fragments.
+5. Review and commit the resulting release diff before creating any tag or
+   announcement.
+
+The command intentionally does not modify Vim runtime files or create tags.
+Version and syntax-snapshot updates remain explicit release-review steps.

--- a/.changeset/adopt-change-fragments.md
+++ b/.changeset/adopt-change-fragments.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+category: changed
+---
+
+- 🧾 **引入可审计的变更片段** / **Adopt auditable change fragments**
+
+新增零依赖的变更片段工作流，可在 PR 中记录语义版本级别和双语发布说明，
+并在发布时按分类汇总到 CHANGELOG。
+
+Added a dependency-free change-fragment workflow that records semantic version
+bumps and bilingual release notes in pull requests, then groups them into the
+changelog during release preparation.

--- a/.changeset/adopt-change-fragments.md
+++ b/.changeset/adopt-change-fragments.md
@@ -5,9 +5,9 @@ category: changed
 
 - 🧾 **引入可审计的变更片段** / **Adopt auditable change fragments**
 
-新增零依赖的变更片段工作流，可在 PR 中记录语义版本级别和双语发布说明，
-并在发布时按分类汇总到 CHANGELOG。
+  新增零依赖的变更片段工作流，可在 PR 中记录语义版本级别和双语发布说明，
+  并在发布时按分类汇总到 CHANGELOG。
 
-Added a dependency-free change-fragment workflow that records semantic version
-bumps and bilingual release notes in pull requests, then groups them into the
-changelog during release preparation.
+  Added a dependency-free change-fragment workflow that records semantic version
+  bumps and bilingual release notes in pull requests, then groups them into the
+  changelog during release preparation.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -27,6 +27,18 @@
       "heading": "📖 Documentation / 文档"
     },
     {
+      "id": "verification",
+      "heading": "🧪 Verification / 验证"
+    },
+    {
+      "id": "integrations",
+      "heading": "🔌 Editor integrations / 编辑器集成"
+    },
+    {
+      "id": "compatibility",
+      "heading": "🔌 Compatibility / 兼容性"
+    },
+    {
       "id": "security",
       "heading": "🔒 Security / 安全"
     }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,34 @@
+{
+  "project": "BIRD.vim",
+  "changelog": "CHANGELOG.md",
+  "categories": [
+    {
+      "id": "breaking",
+      "heading": "💥 Breaking / 破坏性变更"
+    },
+    {
+      "id": "added",
+      "heading": "✨ Added / 新增"
+    },
+    {
+      "id": "changed",
+      "heading": "🔧 Changed / 变更"
+    },
+    {
+      "id": "fixed",
+      "heading": "🐛 Fixed / 修复"
+    },
+    {
+      "id": "performance",
+      "heading": "⚡ Performance / 性能"
+    },
+    {
+      "id": "documentation",
+      "heading": "📖 Documentation / 文档"
+    },
+    {
+      "id": "security",
+      "heading": "🔒 Security / 安全"
+    }
+  ]
+}

--- a/.changeset/rename-and-update-guides.md
+++ b/.changeset/rename-and-update-guides.md
@@ -5,10 +5,10 @@ category: documentation
 
 - 🐦 **更名为 BIRD.vim 并补充升级指南** / **Rename to BIRD.vim and add upgrade guides**
 
-仓库已由 BIRD2.vim 更名为 BIRD.vim，并新增 vim-plug、Vundle、原生 packages
-与手动检出的中英文升级步骤；`bird2` filetype、运行时文件名、变量和 help tag
-保持兼容。
+  仓库已由 BIRD2.vim 更名为 BIRD.vim，并新增 vim-plug、Vundle、原生 packages
+  与手动检出的中英文升级步骤；`bird2` filetype、运行时文件名、变量和 help tag
+  保持兼容。
 
-The repository was renamed from BIRD2.vim to BIRD.vim, with bilingual upgrade
-steps for vim-plug, Vundle, native packages, and manual checkouts. The `bird2`
-filetype, runtime filenames, variables, and help tags remain compatible.
+  The repository was renamed from BIRD2.vim to BIRD.vim, with bilingual upgrade
+  steps for vim-plug, Vundle, native packages, and manual checkouts. The `bird2`
+  filetype, runtime filenames, variables, and help tags remain compatible.

--- a/.changeset/rename-and-update-guides.md
+++ b/.changeset/rename-and-update-guides.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+category: documentation
+---
+
+- 🐦 **更名为 BIRD.vim 并补充升级指南** / **Rename to BIRD.vim and add upgrade guides**
+
+仓库已由 BIRD2.vim 更名为 BIRD.vim，并新增 vim-plug、Vundle、原生 packages
+与手动检出的中英文升级步骤；`bird2` filetype、运行时文件名、变量和 help tag
+保持兼容。
+
+The repository was renamed from BIRD2.vim to BIRD.vim, with bilingual upgrade
+steps for vim-plug, Vundle, native packages, and manual checkouts. The `bird2`
+filetype, runtime filenames, variables, and help tags remain compatible.

--- a/.github/workflows/vim.yml
+++ b/.github/workflows/vim.yml
@@ -8,6 +8,17 @@ permissions:
   contents: read
 
 jobs:
+  changesets:
+    name: Changelog changesets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Validate pending changesets
+        run: node scripts/changeset.mjs check
+
   test:
     name: Vim ${{ matrix.vim }}
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,119 @@
+# Changelog 🕊️
+
+<!-- markdownlint-disable MD024 -->
+
+All notable changes to BIRD.vim are documented in this file.
+
+本文记录 BIRD.vim 的重要变更。
+
+> The bundled syntax describes BIRD configuration syntax for editors. It does
+> not implement or claim coverage of upstream BIRD runtime semantic changes.
+
+<!-- changeset-release-marker -->
+
+## [1.0.13] - 2026-07-17
+
+`1.0.13` 由 [PR #3] 于 2026-07-17 合并，并内置已发布的
+[Vim Syntax 1.0.13-20260717] 语法快照。BIRD.vim 仓库本身尚未为该版本创建
+独立 GitHub Release。
+
+Version `1.0.13` was merged in [PR #3] on 2026-07-17 and embeds the published
+[Vim Syntax 1.0.13-20260717] snapshot. The BIRD.vim repository itself does not
+have a separate GitHub Release for this version.
+
+### ✨ Added / 新增
+
+- 🛰️ **BIRD 2.19 与 BIRD 3.3 配置语法** / **BIRD 2.19 and BIRD 3.3 configuration syntax**
+
+  同步当前与冷门关键字、枚举、CLI 短语、运行时/接口属性、BGP
+  hidden/unknown attributes、`mac` / `mac set` 类型及 `bt_check_assign`。
+
+  Synchronized current and uncommon keywords, enums, CLI phrases,
+  runtime/interface attributes, BGP hidden/unknown attributes, `mac` / `mac set`
+  types, and `bt_check_assign`.
+
+- 🧭 **精确名称与目录识别** / **Exact filename and directory detection**
+
+  新增 `.bird`、`.bird2`、`.bird3`、规范配置文件名，以及 `bird`、`bird2`、
+  `bird3` 配置目录的精确识别。
+
+  Added exact detection for `.bird`, `.bird2`, `.bird3`, canonical
+  configuration filenames, and files under `bird`, `bird2`, or `bird3`
+  configuration directories.
+
+- 💬 **可逆的注释映射** / **Reversible comment mappings**
+
+  新增 buffer-local 普通模式与可视模式注释映射，并保留用户已有的
+  `<Leader>c` 等映射；ftplugin 清理逻辑保持可逆。
+
+  Added buffer-local normal and visual comment mappings while preserving user
+  mappings such as `<Leader>c`; ftplugin cleanup remains reversible.
+
+### 🔧 Changed / 变更
+
+- 🔎 **有界、注释感知的启发式检测** / **Bounded, comment-aware heuristics**
+
+  通用 `.conf` 文件仅扫描前 200 行并忽略注释。BIRD 独有结构可直接命中，
+  较通用结构必须同时出现两个独立信号；已有的非 `conf` filetype 不会被覆盖。
+
+  Generic `.conf` files are scanned only through the first 200 lines with
+  comments ignored. BIRD-specific structures match directly, while generic
+  structures require two independent signals; existing non-`conf` filetypes
+  are preserved.
+
+- 🔄 **支持稍后写入的配置内容** / **Late-populated configuration support**
+
+  新增 `FileType conf` 与 `BufWritePost` 检测路径，可识别打开后才写入或生成的
+  BIRD 配置。
+
+  Added `FileType conf` and `BufWritePost` detection paths for BIRD
+  configurations populated or generated after opening.
+
+### 🐛 Fixed / 修复
+
+- 🐦 **降低通用 `.conf` 误识别** / **Reduced generic `.conf` false positives**
+
+  文件名仅包含 `bird` 不再触发识别，`bluebird.conf`、`hummingbird.conf` 以及
+  nginx、Apache 等配置不会因为单个弱信号而被误判。
+
+  A filename merely containing `bird` no longer triggers detection. Files such
+  as `bluebird.conf`, `hummingbird.conf`, and nginx or Apache configurations are
+  not classified from a single weak signal.
+
+- 🗃️ **typed table 识别边界** / **Typed-table detection boundaries**
+
+  正确识别 `eth table`、`neighbor table` 与 `ipv6 sadr table`，同时排除并非
+  table 声明的 address-family 标签。
+
+  Correctly recognizes `eth table`, `neighbor table`, and `ipv6 sadr table`
+  without treating address-family labels as table declarations.
+
+- 🧵 **字符串、操作符与前缀匹配** / **Strings, operators, and prefix matching**
+
+  修复双引号转义、位运算符冲突、压缩 IPv6 前缀和 IPv4/IPv6 prefix range，
+  并限制 IPv6 正则边界以避免异常长行产生额外开销。
+
+  Fixed double-quoted escapes, bitwise-operator collisions, compressed IPv6
+  prefixes, and IPv4/IPv6 prefix ranges, while bounding IPv6 matching on
+  unusually long lines.
+
+### 🧪 Verification / 验证
+
+- 新增 headless syntax group、filetype detection 与 ftplugin 回归测试。
+- Added headless syntax-group, filetype-detection, and ftplugin regressions.
+- CI 覆盖 Vim `v8.2.0000` 与 stable，且语法文件与共享 canonical snapshot
+  保持逐字节一致。
+- CI covers Vim `v8.2.0000` and stable and verifies that the syntax file is
+  byte-identical to the canonical shared snapshot.
+
+### 🔌 Compatibility / 兼容性
+
+- 对外 filetype 仍为 `bird2`；既有 autocmd、映射、配置变量、runtime 文件名与
+  `:help bird2` 均继续可用。
+- The public filetype remains `bird2`; existing autocmds, mappings,
+  configuration variables, runtime filenames, and `:help bird2` references
+  continue to work.
+
+[1.0.13]: https://github.com/bird-chinese-community/BIRD.vim/pull/3
+[PR #3]: https://github.com/bird-chinese-community/BIRD.vim/pull/3
+[Vim Syntax 1.0.13-20260717]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/vim-v1.0.13-20260717

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,31 @@ All notable changes to BIRD.vim are documented in this file.
 
 > The bundled syntax describes BIRD configuration syntax for editors. It does
 > not implement or claim coverage of upstream BIRD runtime semantic changes.
+>
+> 内置语法用于描述编辑器中的 BIRD 配置语法，不实现也不声称覆盖 BIRD 上游
+> 运行时语义变化。
 
 <!-- changeset-release-marker -->
 
 ## [1.0.13] - 2026-07-17
 
-`1.0.13` 由 [PR #3] 于 2026-07-17 合并，并内置已发布的
-[Vim Syntax 1.0.13-20260717] 语法快照。BIRD.vim 仓库本身尚未为该版本创建
-独立 GitHub Release。
+`1.0.13` 由 [PR #3](https://github.com/bird-chinese-community/BIRD.vim/pull/3)
+于 2026-07-17 合并，并内置已发布的
+[Vim Syntax 1.0.13-20260717](https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/vim-v1.0.13-20260717)
+语法快照。BIRD.vim 仓库本身尚未为该版本创建独立 GitHub Release。
 
-Version `1.0.13` was merged in [PR #3] on 2026-07-17 and embeds the published
-[Vim Syntax 1.0.13-20260717] snapshot. The BIRD.vim repository itself does not
-have a separate GitHub Release for this version.
+Version `1.0.13` was merged in
+[PR #3](https://github.com/bird-chinese-community/BIRD.vim/pull/3) on
+2026-07-17 and embeds the published
+[Vim Syntax 1.0.13-20260717](https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/vim-v1.0.13-20260717)
+snapshot. The BIRD.vim repository itself does not have a separate GitHub
+Release for this version.
 
 ### ✨ Added / 新增
 
 - 🛰️ **BIRD 2.19 与 BIRD 3.3 配置语法** / **BIRD 2.19 and BIRD 3.3 configuration syntax**
 
-  同步当前与冷门关键字、枚举、CLI 短语、运行时/接口属性、BGP
+  同步最新及较少使用的关键字、枚举、CLI 短语、运行时/接口属性、BGP
   hidden/unknown attributes、`mac` / `mac set` 类型及 `bt_check_assign`。
 
   Synchronized current and uncommon keywords, enums, CLI phrases,
@@ -115,5 +122,3 @@ have a separate GitHub Release for this version.
   continue to work.
 
 [1.0.13]: https://github.com/bird-chinese-community/BIRD.vim/pull/3
-[PR #3]: https://github.com/bird-chinese-community/BIRD.vim/pull/3
-[Vim Syntax 1.0.13-20260717]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/vim-v1.0.13-20260717

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ To regenerate help tags:
 :helptags ~/.vim/doc
 ```
 
+See the [changelog](CHANGELOG.md) for release history. Contributors should add
+a bilingual fragment following the [change-fragment guide](.changeset/README.md)
+for user-visible or release-worthy changes.
+
 ## Configuration
 
 No configuration is required. The plugin works out of the box.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,6 +116,9 @@ bash /path/to/bird2.vim/scripts/install.sh
 :helptags ~/.vim/doc
 ```
 
+发布历史参见 [更新日志](CHANGELOG.md)。对于用户可见或需要进入发布说明的变更，
+贡献者应按照 [change fragment 指南](.changeset/README.md) 添加双语片段。
+
 ## 配置
 
 无需配置即可使用。

--- a/scripts/changeset.mjs
+++ b/scripts/changeset.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import {
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CHANGESET_DIR = join(ROOT, ".changeset");
+const CONFIG_PATH = join(CHANGESET_DIR, "config.json");
+const RELEASE_MARKER = "<!-- changeset-release-marker -->";
+const BUMPS = ["patch", "minor", "major"];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function repositoryPath(value, label) {
+  if (typeof value !== "string" || value.length === 0 || isAbsolute(value)) {
+    fail(`${label} must be a non-empty repository-relative path`);
+  }
+  const target = resolve(ROOT, value);
+  const fromRoot = relative(ROOT, target);
+  if (fromRoot === ".." || fromRoot.startsWith(`..${sep}`)) {
+    fail(`${label} must stay inside the repository`);
+  }
+  return target;
+}
+
+function readConfig() {
+  let config;
+  try {
+    config = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+  } catch (error) {
+    fail(`Cannot read .changeset/config.json: ${error.message}`);
+  }
+
+  if (typeof config.project !== "string" || config.project.length === 0) {
+    fail("config.project must be a non-empty string");
+  }
+  repositoryPath(config.changelog, "config.changelog");
+  if (config.releaseLink !== undefined && typeof config.releaseLink !== "string") {
+    fail("config.releaseLink must be a string when provided");
+  }
+  if (config.releaseLink !== undefined && !config.releaseLink.includes("{version}")) {
+    fail("config.releaseLink must contain the {version} placeholder");
+  }
+  if (!Array.isArray(config.categories) || config.categories.length === 0) {
+    fail("config.categories must be a non-empty array");
+  }
+
+  const ids = new Set();
+  for (const category of config.categories) {
+    if (
+      !category ||
+      typeof category.id !== "string" ||
+      !/^[a-z][a-z0-9-]*$/.test(category.id) ||
+      typeof category.heading !== "string" ||
+      category.heading.length === 0
+    ) {
+      fail("each changelog category needs a valid id and heading");
+    }
+    if (ids.has(category.id)) fail(`duplicate category id: ${category.id}`);
+    ids.add(category.id);
+  }
+
+  return { ...config, categoryIds: ids };
+}
+
+function parseFragment(name, source, config) {
+  const normalized = source.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  if (lines[0] !== "---") fail(`${name}: missing opening frontmatter delimiter`);
+  const closing = lines.indexOf("---", 1);
+  if (closing < 0) fail(`${name}: missing closing frontmatter delimiter`);
+
+  const metadata = {};
+  for (const line of lines.slice(1, closing)) {
+    const match = /^([a-z][a-z0-9-]*):\s*(\S(?:.*\S)?)\s*$/.exec(line);
+    if (!match) fail(`${name}: invalid frontmatter line: ${line}`);
+    if (metadata[match[1]] !== undefined) {
+      fail(`${name}: duplicate frontmatter key: ${match[1]}`);
+    }
+    metadata[match[1]] = match[2];
+  }
+
+  const allowed = new Set(["bump", "category"]);
+  for (const key of Object.keys(metadata)) {
+    if (!allowed.has(key)) fail(`${name}: unsupported frontmatter key: ${key}`);
+  }
+  if (!BUMPS.includes(metadata.bump)) {
+    fail(`${name}: bump must be one of ${BUMPS.join(", ")}`);
+  }
+  if (!config.categoryIds.has(metadata.category)) {
+    fail(`${name}: unknown category: ${metadata.category}`);
+  }
+
+  const body = lines.slice(closing + 1).join("\n").trim();
+  if (!body) fail(`${name}: release-note body must not be empty`);
+  if (!body.startsWith("- ")) fail(`${name}: release-note body must start with a list item`);
+  if (body.includes(RELEASE_MARKER)) fail(`${name}: release marker is not allowed in fragment body`);
+  const placeholders = ["中文标题", "English title", "中文说明。", "English summary."];
+  if (placeholders.some((placeholder) => body.includes(placeholder))) {
+    fail(`${name}: replace all generated template placeholders`);
+  }
+
+  return { name, bump: metadata.bump, category: metadata.category, body };
+}
+
+function readFragments(config) {
+  const names = readdirSync(CHANGESET_DIR, { withFileTypes: true })
+    .filter((entry) => entry.name.endsWith(".md") && entry.name !== "README.md")
+    .map((entry) => {
+      if (!entry.isFile()) fail(`${entry.name}: changesets must be regular files`);
+      return entry.name;
+    })
+    .sort();
+
+  return names.map((name) => {
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*\.md$/.test(name)) {
+      fail(`${name}: filename must be kebab-case`);
+    }
+    return parseFragment(name, readFileSync(join(CHANGESET_DIR, name), "utf8"), config);
+  });
+}
+
+function readChangelog(config) {
+  const changelogPath = repositoryPath(config.changelog, "config.changelog");
+  const changelog = readFileSync(changelogPath, "utf8");
+  const markers = changelog.split(RELEASE_MARKER).length - 1;
+  if (markers !== 1) {
+    fail(`${config.changelog} must contain exactly one ${RELEASE_MARKER}`);
+  }
+  return { changelog, changelogPath };
+}
+
+function notesFor(changelog, version) {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    fail("notes requires a semantic version");
+  }
+  const escaped = version.replaceAll(".", "\\.");
+  const heading = new RegExp(
+    `^## (?:\\[)?${escaped}(?:\\])? - \\d{4}-\\d{2}-\\d{2}$`,
+  );
+  const lines = changelog.replace(/\r\n/g, "\n").split("\n");
+  const start = lines.findIndex((line) => heading.test(line));
+  if (start < 0) fail(`CHANGELOG does not contain version ${version}`);
+  const next = lines.findIndex((line, index) => index > start && line.startsWith("## "));
+  const notes = lines.slice(start + 1, next < 0 ? undefined : next).join("\n").trim();
+  if (!notes) fail(`CHANGELOG version ${version} has no release notes`);
+  return notes;
+}
+
+function recommendedBump(fragments) {
+  return fragments.reduce(
+    (highest, fragment) =>
+      BUMPS.indexOf(fragment.bump) > BUMPS.indexOf(highest) ? fragment.bump : highest,
+    "patch",
+  );
+}
+
+function sectionFor(version, date, config, fragments) {
+  const title = config.releaseLink ? `[${version}]` : version;
+  const sections = [`## ${title} - ${date}`];
+  for (const category of config.categories) {
+    const matching = fragments.filter((fragment) => fragment.category === category.id);
+    if (matching.length === 0) continue;
+    sections.push(`### ${category.heading}`);
+    sections.push(matching.map((fragment) => fragment.body).join("\n\n"));
+  }
+  return sections.join("\n\n");
+}
+
+function today() {
+  const now = new Date();
+  const year = String(now.getFullYear());
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function help() {
+  process.stdout.write(`Usage: node scripts/changeset.mjs <command>\n\nCommands:\n  new <slug> <patch|minor|major> <category>\n  check\n  status\n  notes <version>\n  release <version> [--date YYYY-MM-DD] [--dry-run]\n`);
+}
+
+function createFragment(args, config) {
+  if (args.length !== 3) fail("new requires <slug> <bump> <category>");
+  const [slug, bump, category] = args;
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) fail("slug must be kebab-case");
+  if (!BUMPS.includes(bump)) fail(`bump must be one of ${BUMPS.join(", ")}`);
+  if (!config.categoryIds.has(category)) fail(`unknown category: ${category}`);
+
+  const target = join(CHANGESET_DIR, `${slug}.md`);
+  if (existsSync(target)) fail(`changeset already exists: ${slug}.md`);
+  const template = `---\nbump: ${bump}\ncategory: ${category}\n---\n\n- **中文标题** / **English title**\n\n中文说明。\n\nEnglish summary.\n`;
+  writeFileSync(target, template, { encoding: "utf8", flag: "wx" });
+  process.stdout.write(`Created .changeset/${slug}.md\n`);
+}
+
+function printStatus(config, fragments) {
+  process.stdout.write(`${config.project}\n`);
+  process.stdout.write(`Pending changesets: ${fragments.length}\n`);
+  if (fragments.length === 0) return;
+  process.stdout.write(`Recommended bump: ${recommendedBump(fragments)}\n`);
+  for (const fragment of fragments) {
+    const summary = fragment.body.split("\n", 1)[0].replace(/^-\s*/, "");
+    process.stdout.write(`- ${fragment.name} [${fragment.bump}/${fragment.category}] ${summary}\n`);
+  }
+}
+
+function release(args, config, fragments) {
+  if (fragments.length === 0) fail("no pending changesets to release");
+  const version = args.shift();
+  if (!version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    fail("release requires a semantic version");
+  }
+
+  let date = today();
+  let dryRun = false;
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === "--dry-run") dryRun = true;
+    else if (arg === "--date") {
+      date = args.shift();
+      if (!date) fail("--date requires YYYY-MM-DD");
+    } else fail(`unknown release option: ${arg}`);
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) fail("date must use YYYY-MM-DD");
+
+  const { changelog, changelogPath } = readChangelog(config);
+  const heading = config.releaseLink ? `## [${version}]` : `## ${version}`;
+  if (changelog.includes(heading)) fail(`CHANGELOG already contains version ${version}`);
+
+  const section = sectionFor(version, date, config, fragments);
+  if (dryRun) {
+    process.stdout.write(`${section}\n`);
+    return;
+  }
+
+  const [before, after] = changelog.split(RELEASE_MARKER);
+  let next = `${before.trimEnd()}\n\n${RELEASE_MARKER}\n\n${section}\n\n${after.trimStart()}`;
+  if (config.releaseLink) {
+    const link = `[${version}]: ${config.releaseLink.replaceAll("{version}", version)}`;
+    if (next.includes(`${link}\n`) || next.endsWith(link)) fail(`CHANGELOG already defines ${version}`);
+    next = `${next.trimEnd()}\n${link}\n`;
+  } else {
+    next = `${next.trimEnd()}\n`;
+  }
+
+  const temporary = `${changelogPath}.tmp-${process.pid}`;
+  try {
+    writeFileSync(temporary, next, "utf8");
+    renameSync(temporary, changelogPath);
+  } finally {
+    if (existsSync(temporary)) unlinkSync(temporary);
+  }
+  for (const fragment of fragments) unlinkSync(join(CHANGESET_DIR, fragment.name));
+  process.stdout.write(`Released ${version}; consumed ${fragments.length} changeset(s).\n`);
+}
+
+function main() {
+  const [command = "help", ...args] = process.argv.slice(2);
+  if (command === "help" || command === "--help" || command === "-h") {
+    help();
+    return;
+  }
+
+  const config = readConfig();
+  if (command === "new") {
+    createFragment(args, config);
+    return;
+  }
+
+  const { changelog } = readChangelog(config);
+  if (command === "notes") {
+    if (args.length !== 1) fail("notes requires <version>");
+    process.stdout.write(`${notesFor(changelog, args[0])}\n`);
+    return;
+  }
+  const fragments = readFragments(config);
+  if (command === "check") {
+    process.stdout.write(`Validated ${fragments.length} pending changeset(s).\n`);
+  } else if (command === "status") {
+    printStatus(config, fragments);
+  } else if (command === "release") {
+    release(args, config, fragments);
+  } else {
+    fail(`unknown command: ${command}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`changeset: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/changeset.mjs
+++ b/scripts/changeset.mjs
@@ -34,7 +34,7 @@ function repositoryPath(value, label) {
   }
   const target = resolve(ROOT, value);
   const fromRoot = relative(ROOT, target);
-  if (fromRoot === ".." || fromRoot.startsWith(`..${sep}`)) {
+  if (fromRoot === ".." || isAbsolute(fromRoot) || fromRoot.startsWith(`..${sep}`)) {
     fail(`${label} must stay inside the repository`);
   }
   return target;
@@ -80,6 +80,58 @@ function readConfig() {
   return { ...config, categoryIds: ids };
 }
 
+function validateBilingualBody(name, body) {
+  const lines = body.split("\n");
+  const title = lines[0];
+  const firstBold = title.indexOf("**");
+  const separator = title.indexOf("** / **", firstBold + 2);
+  if (
+    !title.startsWith("- ") ||
+    firstBold <= 2 ||
+    separator < 0 ||
+    !title.endsWith("**")
+  ) {
+    fail(`${name}: title must use "- emoji **中文标题** / **English title**"`);
+  }
+
+  const icon = title.slice(2, firstBold).trim();
+  const chineseTitle = title.slice(firstBold + 2, separator);
+  const englishTitle = title.slice(separator + "** / **".length, -2);
+  if (!/\p{Extended_Pictographic}/u.test(icon)) {
+    fail(`${name}: title must start with an emoji`);
+  }
+  if (!/\p{Script=Han}/u.test(chineseTitle)) {
+    fail(`${name}: title must include a Simplified Chinese title first`);
+  }
+  if (!/[A-Za-z]/.test(englishTitle)) {
+    fail(`${name}: title must include an English title second`);
+  }
+
+  const paragraphs = [];
+  let current = [];
+  for (const line of lines.slice(1)) {
+    if (line.trim() === "") {
+      if (current.length > 0) paragraphs.push(current.join("\n"));
+      current = [];
+      continue;
+    }
+    if (!line.startsWith("  ")) {
+      fail(`${name}: paragraphs below the list item must use two-space indentation`);
+    }
+    current.push(line.slice(2));
+  }
+  if (current.length > 0) paragraphs.push(current.join("\n"));
+  if (paragraphs.length < 2) {
+    fail(`${name}: add a Chinese paragraph followed by an English paragraph`);
+  }
+  if (!/\p{Script=Han}/u.test(paragraphs[0])) {
+    fail(`${name}: first paragraph must be Simplified Chinese`);
+  }
+  if (!/[A-Za-z]/.test(paragraphs[paragraphs.length - 1])) {
+    fail(`${name}: final paragraph must be English`);
+  }
+}
+
 function parseFragment(name, source, config) {
   const normalized = source.replace(/\r\n/g, "\n");
   const lines = normalized.split("\n");
@@ -89,6 +141,7 @@ function parseFragment(name, source, config) {
 
   const metadata = {};
   for (const line of lines.slice(1, closing)) {
+    if (line.trim() === "") continue;
     const match = /^([a-z][a-z0-9-]*):\s*(\S(?:.*\S)?)\s*$/.exec(line);
     if (!match) fail(`${name}: invalid frontmatter line: ${line}`);
     if (metadata[match[1]] !== undefined) {
@@ -116,6 +169,7 @@ function parseFragment(name, source, config) {
   if (placeholders.some((placeholder) => body.includes(placeholder))) {
     fail(`${name}: replace all generated template placeholders`);
   }
+  validateBilingualBody(name, body);
 
   return { name, bump: metadata.bump, category: metadata.category, body };
 }
@@ -147,19 +201,51 @@ function readChangelog(config) {
   return { changelog, changelogPath };
 }
 
-function notesFor(changelog, version) {
+function versionHeadingPattern(version, command) {
   if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
-    fail("notes requires a semantic version");
+    fail(`${command} requires a semantic version`);
   }
-  const escaped = version.replaceAll(".", "\\.");
-  const heading = new RegExp(
-    `^## (?:\\[)?${escaped}(?:\\])? - \\d{4}-\\d{2}-\\d{2}$`,
+  const escaped = version.replace(/\./g, "\\.");
+  return new RegExp(
+    `^## (?:\\[${escaped}\\]|${escaped}) - \\d{4}-\\d{2}-\\d{2}\\s*$`,
   );
+}
+
+function findVersionStart(lines, version, command) {
+  const heading = versionHeadingPattern(version, command);
+  return lines.findIndex((line) => heading.test(line));
+}
+
+function stripTrailingLinkDefinitions(lines) {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1].trim() === "") end -= 1;
+
+  while (end > 0) {
+    const line = lines[end - 1].trim();
+    const delimiter = line.indexOf("]:");
+    const isLinkDefinition =
+      line.startsWith("[") &&
+      delimiter > 1 &&
+      line.slice(delimiter + 2).trim().length > 0;
+    if (!isLinkDefinition) break;
+    end -= 1;
+    while (end > 0 && lines[end - 1].trim() === "") end -= 1;
+  }
+
+  return lines.slice(0, end);
+}
+
+function notesFor(changelog, version) {
   const lines = changelog.replace(/\r\n/g, "\n").split("\n");
-  const start = lines.findIndex((line) => heading.test(line));
+  const start = findVersionStart(lines, version, "notes");
   if (start < 0) fail(`CHANGELOG does not contain version ${version}`);
-  const next = lines.findIndex((line, index) => index > start && line.startsWith("## "));
-  const notes = lines.slice(start + 1, next < 0 ? undefined : next).join("\n").trim();
+  const next = lines.findIndex(
+    (line, index) => index > start && line.trimEnd().startsWith("## "),
+  );
+  const noteLines = stripTrailingLinkDefinitions(
+    lines.slice(start + 1, next < 0 ? undefined : next),
+  );
+  const notes = noteLines.join("\n").trim();
   if (!notes) fail(`CHANGELOG version ${version} has no release notes`);
   return notes;
 }
@@ -173,8 +259,7 @@ function recommendedBump(fragments) {
 }
 
 function sectionFor(version, date, config, fragments) {
-  const title = config.releaseLink ? `[${version}]` : version;
-  const sections = [`## ${title} - ${date}`];
+  const sections = [`## [${version}] - ${date}`];
   for (const category of config.categories) {
     const matching = fragments.filter((fragment) => fragment.category === category.id);
     if (matching.length === 0) continue;
@@ -184,11 +269,46 @@ function sectionFor(version, date, config, fragments) {
   return sections.join("\n\n");
 }
 
+function runRegressionChecks() {
+  const fixture = [
+    "## [1.0.14] - 2026-07-18",
+    "",
+    "New notes.",
+    "",
+    "## [1.0.13] - 2026-07-17  ",
+    "",
+    "Old notes.",
+    "",
+    "[1.0.14]: https://example.invalid/1.0.14",
+    "[1.0.13]: https://example.invalid/1.0.13",
+    "",
+  ].join("\n");
+  if (notesFor(fixture, "1.0.13") !== "Old notes.") {
+    fail("internal regression: notes must exclude trailing link definitions");
+  }
+  const lines = fixture.split("\n");
+  if (findVersionStart(lines, "1.0.1", "check") >= 0) {
+    fail("internal regression: version matching must not use prefixes");
+  }
+  if (findVersionStart(lines, "1.0.13", "check") < 0) {
+    fail("internal regression: bracketed headings must be detected");
+  }
+  const section = sectionFor(
+    "1.0.1",
+    "2026-07-18",
+    { categories: [{ id: "fixed", heading: "🐛 Fixed / 修复" }] },
+    [{ category: "fixed", body: "- 🐛 **修复** / **Fix**" }],
+  );
+  if (!section.startsWith("## [1.0.1] - 2026-07-18")) {
+    fail("internal regression: generated headings must use brackets");
+  }
+}
+
 function today() {
   const now = new Date();
-  const year = String(now.getFullYear());
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
+  const year = String(now.getUTCFullYear());
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 
@@ -205,7 +325,9 @@ function createFragment(args, config) {
 
   const target = join(CHANGESET_DIR, `${slug}.md`);
   if (existsSync(target)) fail(`changeset already exists: ${slug}.md`);
-  const template = `---\nbump: ${bump}\ncategory: ${category}\n---\n\n- **中文标题** / **English title**\n\n中文说明。\n\nEnglish summary.\n`;
+  const categoryConfig = config.categories.find((item) => item.id === category);
+  const icon = categoryConfig.heading.split(" ", 1)[0];
+  const template = `---\nbump: ${bump}\ncategory: ${category}\n---\n\n- ${icon} **中文标题** / **English title**\n\n  中文说明。\n\n  English summary.\n`;
   writeFileSync(target, template, { encoding: "utf8", flag: "wx" });
   process.stdout.write(`Created .changeset/${slug}.md\n`);
 }
@@ -224,9 +346,7 @@ function printStatus(config, fragments) {
 function release(args, config, fragments) {
   if (fragments.length === 0) fail("no pending changesets to release");
   const version = args.shift();
-  if (!version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
-    fail("release requires a semantic version");
-  }
+  versionHeadingPattern(version, "release");
 
   let date = today();
   let dryRun = false;
@@ -241,8 +361,10 @@ function release(args, config, fragments) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) fail("date must use YYYY-MM-DD");
 
   const { changelog, changelogPath } = readChangelog(config);
-  const heading = config.releaseLink ? `## [${version}]` : `## ${version}`;
-  if (changelog.includes(heading)) fail(`CHANGELOG already contains version ${version}`);
+  const changelogLines = changelog.replace(/\r\n/g, "\n").split("\n");
+  if (findVersionStart(changelogLines, version, "release") >= 0) {
+    fail(`CHANGELOG already contains version ${version}`);
+  }
 
   const section = sectionFor(version, date, config, fragments);
   if (dryRun) {
@@ -253,8 +375,12 @@ function release(args, config, fragments) {
   const [before, after] = changelog.split(RELEASE_MARKER);
   let next = `${before.trimEnd()}\n\n${RELEASE_MARKER}\n\n${section}\n\n${after.trimStart()}`;
   if (config.releaseLink) {
-    const link = `[${version}]: ${config.releaseLink.replaceAll("{version}", version)}`;
-    if (next.includes(`${link}\n`) || next.endsWith(link)) fail(`CHANGELOG already defines ${version}`);
+    const linkPrefix = `[${version}]:`;
+    if (next.split(/\r?\n/).some((line) => line.startsWith(linkPrefix))) {
+      fail(`CHANGELOG already defines ${version}`);
+    }
+    const releaseUrl = config.releaseLink.replace(/\{version\}/g, version);
+    const link = `${linkPrefix} ${releaseUrl}`;
     next = `${next.trimEnd()}\n${link}\n`;
   } else {
     next = `${next.trimEnd()}\n`;
@@ -292,6 +418,7 @@ function main() {
   }
   const fragments = readFragments(config);
   if (command === "check") {
+    runRegressionChecks();
     process.stdout.write(`Validated ${fragments.length} pending changeset(s).\n`);
   } else if (command === "status") {
     printStatus(config, fragments);


### PR DESCRIPTION
## Summary

- add a BIRD-LSP-style bilingual changelog for the merged BIRD.vim 1.0.13 work
- distinguish the published shared Vim Syntax snapshot from the absence of a separate BIRD.vim GitHub Release
- document syntax, bounded filetype heuristics, false-positive controls, ftplugin behavior, compatibility, and validation
- add a dependency-free change-fragment workflow with `new`, `check`, `status`, `notes`, and `release` commands
- validate pending fragments in CI and capture the repository rename/update guides as a pending patch fragment

## Scope

Coverage statements apply to editor configuration syntax, not upstream BIRD runtime semantics. The public `bird2` filetype and compatibility surface remain unchanged.

## Verification

- `node scripts/changeset.mjs check`
- `node scripts/changeset.mjs status`
- `node scripts/changeset.mjs notes 1.0.13`
- `node scripts/changeset.mjs release 1.0.14 --date 2026-07-18 --dry-run`
- Vim syntax, filetype detection, and ftplugin headless suites
- `actionlint .github/workflows/vim.yml`
- `git diff --check`

## Review follow-up (2026-07-18)

- fix exact version detection, bracketed generated headings, oldest-version note extraction, UTC dates, cross-drive path validation, and Node.js compatibility in the shared script
- generate emoji-prefixed, two-space-indented bilingual fragments and enforce their Chinese/English structure in CI
- convert release-note links to inline Markdown
- add config entries for verification, integrations, and compatibility sections, plus README workflow links
- add built-in regression fixtures for link-definition leakage and version-prefix false positives
- replied to and resolved all three inline review threads
